### PR TITLE
ci: add pip-audit for dependency vulnerability scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,12 @@ jobs:
         bandit -r digital_asset_harvester/ -c pyproject.toml
       continue-on-error: true  # Don't fail CI on security warnings yet
 
+    - name: Dependency vulnerability scan with pip-audit
+      run: |
+        pip install pip-audit
+        pip-audit -r requirements.txt
+        pip-audit -r requirements-dev.txt
+
   integration:
     name: Integration Tests (with Ollama)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Adds automated dependency vulnerability scanning using pip-audit to the CI workflow.

## Changes
- Added pip-audit step to lint job in .github/workflows/ci.yml`n- Scans both equirements.txt and equirements-dev.txt`n
## Audit Results
Manual audit shows **no known vulnerabilities** in current dependencies:
```n$ pip-audit -r requirements.txt
No known vulnerabilities found

$ pip-audit -r requirements-dev.txt
No known vulnerabilities found
```n
Closes #6