### PR TITLE
Enhance Extraction for Coinbase/Binance/Kraken (2025)

### DIFF
--- a/digital_asset_harvester/exporters/koinly.py
+++ b/digital_asset_harvester/exporters/koinly.py
@@ -62,6 +62,14 @@ class KoinlyReportGenerator:
                 "Received Amount": "",
                 "Received Currency": "",
             })
+        elif tx_type == "staking_reward":
+            row.update({
+                "Label": "staking",
+                "Sent Amount": "",
+                "Sent Currency": "",
+                "Received Amount": str(purchase.get("amount", "")),
+                "Received Currency": purchase.get("item_name", ""),
+            })
         else:  # Default to buy
             row.update({
                 "Label": "buy",

--- a/digital_asset_harvester/processing/email_purchase_extractor.py
+++ b/digital_asset_harvester/processing/email_purchase_extractor.py
@@ -250,6 +250,10 @@ class EmailPurchaseExtractor:
         "instant buy",
         "recurring buy",
         "auto-invest",
+        "staking",
+        "reward",
+        "earned",
+        "distribution",
     }
 
     # Email patterns that indicate non-purchase content
@@ -447,10 +451,11 @@ class EmailPurchaseExtractor:
             return None
 
         # Validate required fields based on transaction type
-        is_deposit_or_withdrawal = "deposit" in purchase_data.get("transaction_type", "").lower() or \
-                                   "withdrawal" in purchase_data.get("transaction_type", "").lower()
+        is_deposit_withdrawal_or_reward = "deposit" in purchase_data.get("transaction_type", "").lower() or \
+                                          "withdrawal" in purchase_data.get("transaction_type", "").lower() or \
+                                          "staking_reward" in purchase_data.get("transaction_type", "").lower()
 
-        if is_deposit_or_withdrawal:
+        if is_deposit_withdrawal_or_reward:
             required_fields = {"amount", "item_name", "vendor"}
         else:
             required_fields = {"total_spent", "currency", "amount", "item_name", "vendor"}

--- a/digital_asset_harvester/prompts/manager.py
+++ b/digital_asset_harvester/prompts/manager.py
@@ -42,9 +42,9 @@ EMAIL CONTENT:
 ${email_content}
 
 ANALYSIS CRITERIA:
-- Look for ACTUAL purchase/buy transactions, order confirmations, or trade executions
+- Look for ACTUAL purchase/buy transactions, order confirmations, trade executions, or staking rewards/distributions
 - Cryptocurrency exchanges: Coinbase, Binance, Kraken, Gemini, etc.
-- Purchase indicators: "bought", "purchased", "order filled", "transaction completed", "payment processed"
+- Purchase indicators: "bought", "purchased", "order filled", "transaction completed", "payment processed", "staking reward", "earned", "distribution confirmation"
 - Specific amounts and cryptocurrency names (Bitcoin, Ethereum, BTC, ETH, etc.)
 - Transaction IDs, order numbers, or confirmation codes
 
@@ -84,27 +84,29 @@ Extract the following information with high accuracy:
 
 COMMON EMAIL PATTERNS TO LOOK FOR:
 - Coinbase: "You bought X BTC for $Y USD", "Order #12345 completed"
-- Binance: "Buy order filled", "Transaction completed", "Deposit Successful", "Withdrawal Successful"
-- Kraken: "Order executed", "Trade confirmation"
-- General: "Purchase confirmation", "Transaction receipt", "Order summary"
+- Binance: "Buy order filled", "Transaction completed", "Deposit Successful", "Withdrawal Successful", "Distribution Confirmation"
+- Kraken: "Order executed", "Trade confirmation", "Staking Reward Received"
+- General: "Purchase confirmation", "Transaction receipt", "Order summary", "You just earned X staking rewards"
 
 EXTRACTION EXAMPLES:
-- "You bought 0.001 BTC for $25.00 USD" → total_spent: 25.00, currency: "USD", amount: 0.001, item_name: "BTC"
-- "Order filled: 0.5 ETH at $1,500.00" → total_spent: 1500.00, currency: "USD", amount: 0.5, item_name: "ETH"
-- "Binance - Deposit Successful - You've received 0.1 BTC" → total_spent: null, currency: null, amount: 0.1, item_name: "BTC"
-- "$100.00 USD → 0.0025 Bitcoin" → total_spent: 100.00, currency: "USD", amount: 0.0025, item_name: "Bitcoin"
+- "You bought 0.001 BTC for $25.00 USD" → total_spent: 25.00, currency: "USD", amount: 0.001, item_name: "BTC", transaction_type: "buy"
+- "Order filled: 0.5 ETH at $1,500.00" → total_spent: 1500.00, currency: "USD", amount: 0.5, item_name: "ETH", transaction_type: "buy"
+- "Binance - Deposit Successful - You've received 0.1 BTC" → total_spent: null, currency: null, amount: 0.1, item_name: "BTC", transaction_type: "deposit"
+- "You just earned 0.0001 ETH in staking rewards" → total_spent: null, currency: null, amount: 0.0001, item_name: "ETH", transaction_type: "staking_reward"
+- "$100.00 USD → 0.0025 Bitcoin" → total_spent: 100.00, currency: "USD", amount: 0.0025, item_name: "Bitcoin", transaction_type: "buy"
 
 IMPORTANT RULES:
 - Extract EXACT numerical values, don't round or estimate
 - Use null for any field you cannot determine with confidence
 - For item_name, use the EXACT term from the email (BTC vs Bitcoin, ETH vs Ethereum)
 - For vendor, extract the actual company name, not generic terms
+- Extract transaction IDs, reference numbers, or order numbers into a "transaction_id" field if available
 - Parse dates carefully - look for transaction time, not email send time
 - If timezone missing, assume ${default_timezone}
 
 Return JSON with this exact structure:
 {
-    "transaction_type": "buy" | "deposit" | "withdrawal",
+    "transaction_type": "buy" | "deposit" | "withdrawal" | "staking_reward",
     "total_spent": float or null,
     "currency": string or null,
     "amount": float or null, 

--- a/digital_asset_harvester/validation/schemas.py
+++ b/digital_asset_harvester/validation/schemas.py
@@ -15,7 +15,7 @@ class PurchaseRecord:
     item_name: str
     vendor: str
     purchase_date: str
-    transaction_type: str
+    transaction_type: str = "buy"
     transaction_id: Optional[str] = None
     confidence: Optional[float] = None
     extraction_method: Optional[str] = None

--- a/tests/exporters/test_koinly.py
+++ b/tests/exporters/test_koinly.py
@@ -94,6 +94,23 @@ class TestKoinlyReportGenerator:
         assert withdrawal_row["TxHash"] == "txn789"
         assert withdrawal_row["Description"] == "Withdrawal from Kraken"
 
+    def test_convert_staking_reward_to_koinly_row(self):
+        generator = KoinlyReportGenerator()
+        reward = {
+            "transaction_type": "staking_reward",
+            "amount": Decimal("0.01"),
+            "item_name": "ETH",
+            "vendor": "Coinbase",
+            "purchase_date": "2024-01-01",
+        }
+        row = generator._convert_purchase_to_koinly_row(reward)
+        assert row["Label"] == "staking"
+        assert row["Received Amount"] == "0.01"
+        assert row["Received Currency"] == "ETH"
+        assert row["Sent Amount"] == ""
+        assert row["Sent Currency"] == ""
+        assert row["Description"] == "Staking_reward from Coinbase"
+
     def test_generate_csv_rows(self, sample_purchases):
         generator = KoinlyReportGenerator()
         purchase_dicts = [vars(p) for p in sample_purchases]

--- a/tests/fixtures/emails.py
+++ b/tests/fixtures/emails.py
@@ -144,6 +144,28 @@ EMAIL_FIXTURES = {
     You have successfully withdrawn 0.5 ETH.
     Transaction ID: BIN-WDR-2024-002
     """,
+    "coinbase_staking_reward": """
+    From: Coinbase <no-reply@coinbase.com>
+    Subject: You've earned a staking reward
+
+    You just earned 0.00001234 ETH in staking rewards!
+    Your new balance is 1.23456789 ETH.
+    Transaction ID: CB-STAKE-2025-ABC
+    """,
+    "binance_staking_reward": """
+    From: Binance <do-not-reply@binance.com>
+    Subject: Distribution Confirmation
+
+    Your account has been credited with 0.5 SOL for SOL Staking.
+    Reference: BIN-STAKE-2025-XYZ
+    """,
+    "kraken_staking_reward": """
+    From: Kraken <noreply@kraken.com>
+    Subject: Staking Reward Received
+
+    We've credited your account with 10.5 ADA in staking rewards.
+    ID: KR-STAKE-2025-999
+    """,
 }
 
 

--- a/tests/test_email_purchase_extractor.py
+++ b/tests/test_email_purchase_extractor.py
@@ -327,3 +327,126 @@ def test_process_email_with_binance_withdrawal_fixture(mocker, monkeypatch):
     assert result["purchase_info"]["vendor"] == "Binance"
     assert result["purchase_info"]["amount"] == 0.5
     assert result["purchase_info"]["item_name"] == "ETH"
+
+
+def test_process_email_with_coinbase_staking_reward(mocker, monkeypatch):
+    email_content = EMAIL_FIXTURES["coinbase_staking_reward"]
+    mock_llm_client = mocker.Mock()
+    mock_llm_client.generate_json.side_effect = [
+        mocker.Mock(
+            data={
+                "is_crypto_purchase": True,
+                "confidence": 0.9,
+                "reasoning": "Staking reward earned",
+            }
+        ),
+        mocker.Mock(
+            data={
+                "transaction_type": "staking_reward",
+                "total_spent": None,
+                "currency": None,
+                "amount": 0.00001234,
+                "item_name": "ETH",
+                "vendor": "Coinbase",
+                "purchase_date": "2025-01-01 12:00:00",
+                "transaction_id": "CB-STAKE-2025-ABC",
+                "confidence": 0.9,
+                "extraction_notes": "",
+            }
+        ),
+    ]
+    from digital_asset_harvester.processing.email_purchase_extractor import (
+        EmailPurchaseExtractor,
+    )
+
+    extractor = EmailPurchaseExtractor(llm_client=mock_llm_client)
+    monkeypatch.setattr(extractor, "_should_skip_llm_analysis", lambda x: False)
+    monkeypatch.setattr(extractor, "_is_likely_crypto_related", lambda x: True)
+    monkeypatch.setattr(extractor, "_is_likely_purchase_related", lambda x: True)
+    result = extractor.process_email(email_content)
+    assert result["has_purchase"] is True
+    assert result["purchase_info"]["transaction_type"] == "staking_reward"
+    assert result["purchase_info"]["amount"] == 0.00001234
+    assert result["purchase_info"]["transaction_id"] == "CB-STAKE-2025-ABC"
+
+
+def test_process_email_with_binance_staking_reward(mocker, monkeypatch):
+    email_content = EMAIL_FIXTURES["binance_staking_reward"]
+    mock_llm_client = mocker.Mock()
+    mock_llm_client.generate_json.side_effect = [
+        mocker.Mock(
+            data={
+                "is_crypto_purchase": True,
+                "confidence": 0.9,
+                "reasoning": "Distribution confirmation",
+            }
+        ),
+        mocker.Mock(
+            data={
+                "transaction_type": "staking_reward",
+                "total_spent": None,
+                "currency": None,
+                "amount": 0.5,
+                "item_name": "SOL",
+                "vendor": "Binance",
+                "purchase_date": "2025-01-01 12:00:00",
+                "transaction_id": "BIN-STAKE-2025-XYZ",
+                "confidence": 0.9,
+                "extraction_notes": "",
+            }
+        ),
+    ]
+    from digital_asset_harvester.processing.email_purchase_extractor import (
+        EmailPurchaseExtractor,
+    )
+
+    extractor = EmailPurchaseExtractor(llm_client=mock_llm_client)
+    monkeypatch.setattr(extractor, "_should_skip_llm_analysis", lambda x: False)
+    monkeypatch.setattr(extractor, "_is_likely_crypto_related", lambda x: True)
+    monkeypatch.setattr(extractor, "_is_likely_purchase_related", lambda x: True)
+    result = extractor.process_email(email_content)
+    assert result["has_purchase"] is True
+    assert result["purchase_info"]["transaction_type"] == "staking_reward"
+    assert result["purchase_info"]["amount"] == 0.5
+    assert result["purchase_info"]["transaction_id"] == "BIN-STAKE-2025-XYZ"
+
+
+def test_process_email_with_kraken_staking_reward(mocker, monkeypatch):
+    email_content = EMAIL_FIXTURES["kraken_staking_reward"]
+    mock_llm_client = mocker.Mock()
+    mock_llm_client.generate_json.side_effect = [
+        mocker.Mock(
+            data={
+                "is_crypto_purchase": True,
+                "confidence": 0.9,
+                "reasoning": "Staking reward received",
+            }
+        ),
+        mocker.Mock(
+            data={
+                "transaction_type": "staking_reward",
+                "total_spent": None,
+                "currency": None,
+                "amount": 10.5,
+                "item_name": "ADA",
+                "vendor": "Kraken",
+                "purchase_date": "2025-01-01 12:00:00",
+                "transaction_id": "KR-STAKE-2025-999",
+                "confidence": 0.9,
+                "extraction_notes": "",
+            }
+        ),
+    ]
+    from digital_asset_harvester.processing.email_purchase_extractor import (
+        EmailPurchaseExtractor,
+    )
+
+    extractor = EmailPurchaseExtractor(llm_client=mock_llm_client)
+    monkeypatch.setattr(extractor, "_should_skip_llm_analysis", lambda x: False)
+    monkeypatch.setattr(extractor, "_is_likely_crypto_related", lambda x: True)
+    monkeypatch.setattr(extractor, "_is_likely_purchase_related", lambda x: True)
+    result = extractor.process_email(email_content)
+    assert result["has_purchase"] is True
+    assert result["purchase_info"]["transaction_type"] == "staking_reward"
+    assert result["purchase_info"]["amount"] == 10.5
+    assert result["purchase_info"]["transaction_id"] == "KR-STAKE-2025-999"

--- a/tests/test_koinly_writer.py
+++ b/tests/test_koinly_writer.py
@@ -2,7 +2,7 @@
 import os
 import tempfile
 import csv
-from digital_asset_harvester.output.koinly_writer import (
+from digital_asset_harvester.exporters.koinly import (
     KoinlyReportGenerator,
     write_purchase_data_to_koinly_csv,
 )


### PR DESCRIPTION
This PR enhances the tool's ability to extract cryptocurrency transaction information from modern (2024/2025) email formats of major exchanges like Coinbase, Binance, and Kraken. It specifically adds support for identifying and extracting staking rewards and distributions, which were previously often missed or failed validation.

Key changes:
- **Keyword Pre-filtering**: Added "staking", "reward", "earned", and "distribution" to the initial keyword check to ensure these emails are passed to the LLM for analysis.
- **LLM Prompts**: Updated both classification and extraction prompts with realistic 2024/2025 examples from the top 3 exchanges. Added a new `staking_reward` transaction type.
- **Validation Logic**: Modified the `EmailPurchaseExtractor` to recognize that staking rewards, like deposits and withdrawals, do not require `total_spent` or `currency` fields.
- **Koinly Integration**: Updated the Koinly CSV exporter to map the new `staking_reward` type to Koinly's 'staking' label.
- **Data Model**: Added a default value to `PurchaseRecord.transaction_type` to maintain compatibility with existing code and tests.
- **Testing**: Added comprehensive new test fixtures and unit tests covering staking reward extraction for all three major exchanges. Fixed a pre-existing broken test file (`tests/test_koinly_writer.py`).

Fixes #101

---
*PR created automatically by Jules for task [2272037968630271652](https://jules.google.com/task/2272037968630271652) started by @username-anthony-is-not-available*