### PR TITLE
Enhance Binance extraction logic for multi-asset emails

### DIFF
--- a/digital_asset_harvester/cli.py
+++ b/digital_asset_harvester/cli.py
@@ -165,17 +165,17 @@ def process_emails(
                 logger.debug("Email %d: %s", idx, note)
 
         if result.get("has_purchase"):
-            purchase_info = result["purchase_info"]
-            purchase_info["email_subject"] = email.get("subject", "")
-            results.append(purchase_info)
-            metrics.increment("purchases_detected")
-            log_event(
-                app_logger,
-                "purchase_detected",
-                vendor=purchase_info.get("vendor", "unknown"),
-                currency=purchase_info.get("currency", ""),
-                amount=purchase_info.get("amount", 0),
-            )
+            for purchase_info in result.get("purchases", []):
+                purchase_info["email_subject"] = email.get("subject", "")
+                results.append(purchase_info)
+                metrics.increment("purchases_detected")
+                log_event(
+                    app_logger,
+                    "purchase_detected",
+                    vendor=purchase_info.get("vendor", "unknown"),
+                    currency=purchase_info.get("currency", ""),
+                    amount=purchase_info.get("amount", 0),
+                )
         else:
             metrics.increment("non_purchase_emails")
 

--- a/digital_asset_harvester/processing/email_purchase_extractor.py
+++ b/digital_asset_harvester/processing/email_purchase_extractor.py
@@ -254,6 +254,8 @@ class EmailPurchaseExtractor:
         "reward",
         "earned",
         "distribution",
+        "trade confirmation",
+        "order execution",
     }
 
     # Email patterns that indicate non-purchase content
@@ -423,7 +425,7 @@ class EmailPurchaseExtractor:
         email_content: str,
         max_retries: Optional[int] = None,
         default_timezone: str = "UTC",
-    ) -> Optional[Dict[str, Any]]:
+    ) -> List[Dict[str, Any]]:
         retries = (
             max_retries if max_retries is not None else self.settings.llm_max_retries
         )
@@ -442,109 +444,122 @@ class EmailPurchaseExtractor:
             logger.error(
                 "Failed to extract purchase info after %d attempts: %s", retries, exc
             )
-            return None
+            return []
 
-        purchase_data = result.data
+        payload = result.data
 
-        if purchase_data is None:
+        if not payload or "transactions" not in payload:
             logger.info("No purchase information found in the email")
-            return None
+            return []
 
-        # Validate required fields based on transaction type
-        is_deposit_withdrawal_or_reward = "deposit" in purchase_data.get("transaction_type", "").lower() or \
-                                          "withdrawal" in purchase_data.get("transaction_type", "").lower() or \
-                                          "staking_reward" in purchase_data.get("transaction_type", "").lower()
+        transactions = payload.get("transactions", [])
+        if not isinstance(transactions, list):
+            logger.warning("Expected transactions list, but got %s", type(transactions))
+            return []
 
-        if is_deposit_withdrawal_or_reward:
-            required_fields = {"amount", "item_name", "vendor"}
-        else:
-            required_fields = {"total_spent", "currency", "amount", "item_name", "vendor"}
-
-        missing_fields = {
-            field
-            for field in required_fields
-            if field not in purchase_data or purchase_data[field] is None
-        }
-
-        # Log extraction quality
-        confidence = purchase_data.get("confidence", 0.5)
-        notes = purchase_data.get("extraction_notes", "")
-        logger.info("Extraction confidence: %.2f - %s", confidence, notes)
-        log_event(
-            self.event_logger,
-            "extraction_completed",
-            confidence=confidence,
-            missing_fields=";".join(sorted(missing_fields)) if missing_fields else "",
-        )
-
-        if (
-            confidence < self.settings.min_confidence_threshold
-            and self.settings.strict_validation
-        ):
-            logger.warning(
-                "Extraction confidence %.2f below threshold %.2f",
-                confidence,
-                self.settings.min_confidence_threshold,
+        extracted_purchases = []
+        for purchase_data in transactions:
+            # Validate required fields based on transaction type
+            is_deposit_withdrawal_or_reward = (
+                "deposit" in purchase_data.get("transaction_type", "").lower()
+                or "withdrawal" in purchase_data.get("transaction_type", "").lower()
+                or "staking_reward" in purchase_data.get("transaction_type", "").lower()
             )
-            return None
 
-        if missing_fields:
-            logger.warning(
-                "Missing required field(s): %s", ", ".join(sorted(missing_fields))
+            if is_deposit_withdrawal_or_reward:
+                required_fields = {"amount", "item_name", "vendor"}
+            else:
+                required_fields = {
+                    "total_spent",
+                    "currency",
+                    "amount",
+                    "item_name",
+                    "vendor",
+                }
+
+            missing_fields = {
+                field
+                for field in required_fields
+                if field not in purchase_data or purchase_data[field] is None
+            }
+
+            # Log extraction quality
+            confidence = purchase_data.get("confidence", 0.5)
+            notes = purchase_data.get("extraction_notes", "")
+            logger.info("Extraction confidence: %.2f - %s", confidence, notes)
+            log_event(
+                self.event_logger,
+                "extraction_completed",
+                confidence=confidence,
+                missing_fields=";".join(sorted(missing_fields))
+                if missing_fields
+                else "",
             )
-            if self.settings.strict_validation:
-                return None
 
-        # Process the purchase date
-        if purchase_data.get("purchase_date"):
-            try:
-                # Parse the date and ensure it's in UTC
-                date_str = purchase_data["purchase_date"]
-                # Handle various date formats
-                if "T" in date_str:
-                    date = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
-                else:
-                    # Try to parse common date formats
-                    for fmt in [
-                        "%Y-%m-%d %H:%M:%S",
-                        "%Y-%m-%d",
-                        "%m/%d/%Y %H:%M:%S",
-                        "%m/%d/%Y",
-                    ]:
-                        try:
-                            date = datetime.strptime(date_str, fmt)
-                            break
-                        except ValueError:
-                            continue
+            if (
+                confidence < self.settings.min_confidence_threshold
+                and self.settings.strict_validation
+            ):
+                logger.warning(
+                    "Extraction confidence %.2f below threshold %.2f",
+                    confidence,
+                    self.settings.min_confidence_threshold,
+                )
+                continue
+
+            if missing_fields:
+                logger.warning(
+                    "Missing required field(s): %s", ", ".join(sorted(missing_fields))
+                )
+                if self.settings.strict_validation:
+                    continue
+
+            # Process the purchase date
+            if purchase_data.get("purchase_date"):
+                try:
+                    # Parse the date and ensure it's in UTC
+                    date_str = purchase_data["purchase_date"]
+                    # Handle various date formats
+                    if "T" in date_str:
+                        date = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
                     else:
-                        raise ValueError(f"Unable to parse date: {date_str}")
+                        # Try to parse common date formats
+                        for fmt in [
+                            "%Y-%m-%d %H:%M:%S",
+                            "%Y-%m-%d",
+                            "%m/%d/%Y %H:%M:%S",
+                            "%m/%d/%Y",
+                        ]:
+                            try:
+                                date = datetime.strptime(date_str, fmt)
+                                break
+                            except ValueError:
+                                continue
+                        else:
+                            raise ValueError(f"Unable to parse date: {date_str}")
 
-                if date.tzinfo is None:
-                    date = date.replace(tzinfo=timezone.utc)
-                else:
-                    date = date.astimezone(timezone.utc)
-                purchase_data["purchase_date"] = date.strftime("%Y-%m-%d %H:%M:%S %Z")
-            except (ValueError, TypeError) as e:
-                logger.warning("Invalid date format (%s). Using current time.", e)
+                    if date.tzinfo is None:
+                        date = date.replace(tzinfo=timezone.utc)
+                    else:
+                        date = date.astimezone(timezone.utc)
+                    purchase_data["purchase_date"] = date.strftime(
+                        "%Y-%m-%d %H:%M:%S %Z"
+                    )
+                except (ValueError, TypeError) as e:
+                    logger.warning("Invalid date format (%s). Using current time.", e)
+                    purchase_data["purchase_date"] = datetime.now(timezone.utc).strftime(
+                        "%Y-%m-%d %H:%M:%S %Z"
+                    )
+            else:
+                logger.warning("No purchase date found, using current time")
                 purchase_data["purchase_date"] = datetime.now(timezone.utc).strftime(
                     "%Y-%m-%d %H:%M:%S %Z"
                 )
-        else:
-            logger.warning("No purchase date found, using current time")
-            purchase_data["purchase_date"] = datetime.now(timezone.utc).strftime(
-                "%Y-%m-%d %H:%M:%S %Z"
-            )
 
-        purchase_data["extraction_method"] = "llm"
+            purchase_data["extraction_method"] = "llm"
+            extracted_purchases.append(purchase_data)
 
-        # Clean up the response by removing extraction metadata
-        # cleaned_data = {
-        #     k: v
-        #     for k, v in purchase_data.items()
-        #     if k not in ["extraction_notes"]
-        # }
-
-        return purchase_data
+        return extracted_purchases
 
     def _validate_purchase_data(self, purchase_data: Dict[str, Any]) -> bool:
         """Validate extracted purchase data for basic sanity checks."""
@@ -583,42 +598,59 @@ class EmailPurchaseExtractor:
             logger.debug("Email classified as non-crypto-purchase")
             return {
                 "has_purchase": False,
+                "purchases": [],
                 "processing_notes": ["Email not classified as crypto purchase"],
             }
 
         # If classified as purchase, extract the details
-        purchase_info = self.extract_purchase_info(email_content)
+        extracted_purchases = self.extract_purchase_info(email_content)
 
-        if not purchase_info:
+        if not extracted_purchases:
             logger.warning(
                 "Failed to extract purchase information despite positive classification"
             )
             processing_notes.append("Classification positive but extraction failed")
             return {
                 "has_purchase": False,
+                "purchases": [],
                 "processing_notes": processing_notes,
             }
 
-        # Create a PurchaseRecord to pass to calculate_confidence
-        purchase_record = PurchaseRecord.from_raw(purchase_info)
+        validated_purchases = []
+        for purchase_info in extracted_purchases:
+            # Create a PurchaseRecord to pass to calculate_confidence
+            try:
+                purchase_record = PurchaseRecord.from_raw(purchase_info)
 
-        # Calculate and update the confidence score
-        purchase_info["confidence"] = calculate_confidence(purchase_record)
+                # Calculate and update the confidence score
+                purchase_info["confidence"] = calculate_confidence(purchase_record)
 
-        # Validate the extracted data
-        if not self._validate_purchase_data(purchase_info):
-            logger.warning("Extracted purchase data failed validation")
-            processing_notes.append("Extracted data failed validation checks")
+                # Validate the extracted data
+                if self._validate_purchase_data(purchase_info):
+                    validated_purchases.append(purchase_info)
+                else:
+                    logger.warning("Extracted purchase data failed validation")
+                    processing_notes.append(
+                        f"Extracted data for {purchase_info.get('item_name')} failed validation"
+                    )
+            except Exception as e:
+                logger.warning("Error processing extracted purchase: %s", e)
+                processing_notes.append(f"Error processing extracted purchase: {e}")
+
+        if not validated_purchases:
             return {
                 "has_purchase": False,
+                "purchases": [],
                 "processing_notes": processing_notes,
             }
 
         logger.info("Successfully processed crypto purchase email")
-        processing_notes.append("Successfully extracted and validated purchase data")
+        processing_notes.append(
+            f"Successfully extracted and validated {len(validated_purchases)} purchase(s)"
+        )
 
         return {
             "has_purchase": True,
-            "purchase_info": purchase_info,
+            "purchases": validated_purchases,
             "processing_notes": processing_notes,
         }

--- a/digital_asset_harvester/prompts/manager.py
+++ b/digital_asset_harvester/prompts/manager.py
@@ -84,7 +84,7 @@ Extract the following information with high accuracy:
 
 COMMON EMAIL PATTERNS TO LOOK FOR:
 - Coinbase: "You bought X BTC for $Y USD", "Order #12345 completed"
-- Binance: "Buy order filled", "Transaction completed", "Deposit Successful", "Withdrawal Successful", "Distribution Confirmation"
+- Binance: "Buy order filled", "Transaction completed", "Deposit Successful", "Withdrawal Successful", "Distribution Confirmation", "Trade Confirmation", "Order Execution Notice"
 - Kraken: "Order executed", "Trade confirmation", "Staking Reward Received"
 - General: "Purchase confirmation", "Transaction receipt", "Order summary", "You just earned X staking rewards"
 
@@ -94,29 +94,37 @@ EXTRACTION EXAMPLES:
 - "Binance - Deposit Successful - You've received 0.1 BTC" → total_spent: null, currency: null, amount: 0.1, item_name: "BTC", transaction_type: "deposit"
 - "You just earned 0.0001 ETH in staking rewards" → total_spent: null, currency: null, amount: 0.0001, item_name: "ETH", transaction_type: "staking_reward"
 - "$100.00 USD → 0.0025 Bitcoin" → total_spent: 100.00, currency: "USD", amount: 0.0025, item_name: "Bitcoin", transaction_type: "buy"
+- "Trade Confirmation: BTC/USDT 0.01 @ 60000; ETH/USDT 0.5 @ 3000" → Extract TWO transactions: 1. BTC, 2. ETH.
 
 IMPORTANT RULES:
-- Extract EXACT numerical values, don't round or estimate
-- Use null for any field you cannot determine with confidence
-- For item_name, use the EXACT term from the email (BTC vs Bitcoin, ETH vs Ethereum)
-- For vendor, extract the actual company name, not generic terms
-- Extract transaction IDs, reference numbers, or order numbers into a "transaction_id" field if available
-- Parse dates carefully - look for transaction time, not email send time
-- If timezone missing, assume ${default_timezone}
+- Extract ALL transactions found in the email into the "transactions" array.
+- Extract EXACT numerical values, don't round or estimate.
+- Use null for any field you cannot determine with confidence.
+- For item_name, use the EXACT term from the email (BTC vs Bitcoin, ETH vs Ethereum).
+- For vendor, extract the actual company name (e.g., Binance, Coinbase).
+- Extract transaction IDs, reference numbers, or order numbers into a "transaction_id" field if available.
+- Parse dates carefully - look for transaction time, not email send time.
+- For Binance "Trade Confirmation" emails, look for "Executed" or "Amount" for the crypto quantity, and "Total" for the fiat/stablecoin cost.
+- If timezone missing, assume ${default_timezone}.
 
 Return JSON with this exact structure:
 {
-    "transaction_type": "buy" | "deposit" | "withdrawal" | "staking_reward",
-    "total_spent": float or null,
-    "currency": string or null,
-    "amount": float or null, 
-    "item_name": string or null,
-    "vendor": string or null,
-    "purchase_date": string or null,
-    "confidence": float (0.0 to 1.0),
-    "extraction_notes": "Any relevant notes about extraction quality or concerns"
+    "transactions": [
+        {
+            "transaction_type": "buy" | "deposit" | "withdrawal" | "staking_reward",
+            "total_spent": float or null,
+            "currency": string or null,
+            "amount": float or null,
+            "item_name": string or null,
+            "vendor": string or null,
+            "purchase_date": string or null,
+            "transaction_id": string or null,
+            "confidence": float (0.0 to 1.0),
+            "extraction_notes": "Any relevant notes about extraction quality or concerns"
+        }
+    ]
 }
 
-If no valid purchase information can be extracted, return null for the entire object.
+If no valid purchase information can be extracted, return an empty array for the "transactions" field.
 """,
 )

--- a/digital_asset_harvester/validation/validators.py
+++ b/digital_asset_harvester/validation/validators.py
@@ -12,7 +12,7 @@ from .schemas import PurchaseRecord
 
 logger = logging.getLogger(__name__)
 
-ISO_CURRENCY_PATTERN = re.compile(r"^[A-Z]{3}$")
+ISO_CURRENCY_PATTERN = re.compile(r"^[A-Z]{3,5}$")
 CRYPTO_SYMBOL_PATTERN = re.compile(r"^[A-Z0-9]{2,10}$")
 
 KNOWN_CRYPTO_NAMES = {

--- a/tests/fixtures/emails.py
+++ b/tests/fixtures/emails.py
@@ -166,6 +166,42 @@ EMAIL_FIXTURES = {
     We've credited your account with 10.5 ADA in staking rewards.
     ID: KR-STAKE-2025-999
     """,
+    "binance_multi_asset": """
+    From: Binance <do-not-reply@binance.com>
+    Subject: Trade Confirmation
+    Date: Wed, 20 Mar 2024 14:00:00 +0000
+
+    Your trade order has been filled.
+
+    Order Details:
+    - Pair: BTC/USDT
+    - Side: Buy
+    - Amount: 0.002 BTC
+    - Price: 65,000.00 USDT
+    - Total: 130.00 USDT
+    - Fee: 0.000002 BTC
+
+    - Pair: ETH/USDT
+    - Side: Buy
+    - Amount: 0.1 ETH
+    - Price: 3,500.00 USDT
+    - Total: 350.00 USDT
+    - Fee: 0.0001 ETH
+    """,
+    "binance_order_execution": """
+    From: Binance <do-not-reply@binance.com>
+    Subject: Order Execution Notice
+    Date: Thu, 21 Mar 2024 09:15:00 +0000
+
+    Your order #987654321 has been executed.
+
+    Details:
+    Trading Pair: SOL/USDT
+    Amount: 5.0 SOL
+    Price: 180.00 USDT
+    Total Cost: 900.00 USDT
+    Fee: 0.005 SOL
+    """,
 }
 
 
@@ -201,6 +237,8 @@ def purchase_emails():
         "partial_data_purchase",
         "multi_currency_purchase",
         "encoded_subject_purchase",
+        "binance_multi_asset",
+        "binance_order_execution",
     }
     return {k: v for k, v in EMAIL_FIXTURES.items() if k in purchase_types}
 

--- a/tests/test_binance_extraction.py
+++ b/tests/test_binance_extraction.py
@@ -1,0 +1,98 @@
+"""Tests for Binance-specific extraction improvements."""
+
+from __future__ import annotations
+import pytest
+from digital_asset_harvester import get_settings_with_overrides
+from digital_asset_harvester.processing.email_purchase_extractor import EmailPurchaseExtractor
+from tests.fixtures.emails import EMAIL_FIXTURES
+
+def test_extract_binance_multi_asset(mocker, monkeypatch):
+    """Test that multiple assets are correctly extracted from a Binance trade confirmation."""
+    email_content = EMAIL_FIXTURES["binance_multi_asset"]
+
+    # Mock the LLM to return two transactions as expected from the new prompt
+    mock_llm_client = mocker.Mock()
+    mock_llm_client.generate_json.side_effect = [
+        # Classification
+        mocker.Mock(data={"is_crypto_purchase": True, "confidence": 0.95, "reasoning": "Trade confirmation"}),
+        # Extraction
+        mocker.Mock(data={
+            "transactions": [
+                {
+                    "transaction_type": "buy",
+                    "total_spent": 130.0,
+                    "currency": "USDT",
+                    "amount": 0.002,
+                    "item_name": "BTC",
+                    "vendor": "Binance",
+                    "purchase_date": "2024-03-20 14:00:00",
+                    "confidence": 0.95,
+                },
+                {
+                    "transaction_type": "buy",
+                    "total_spent": 350.0,
+                    "currency": "USDT",
+                    "amount": 0.1,
+                    "item_name": "ETH",
+                    "vendor": "Binance",
+                    "purchase_date": "2024-03-20 14:00:00",
+                    "confidence": 0.95,
+                }
+            ]
+        })
+    ]
+
+    settings = get_settings_with_overrides(enable_preprocessing=False)
+    extractor = EmailPurchaseExtractor(settings=settings, llm_client=mock_llm_client)
+
+    result = extractor.process_email(email_content)
+
+    assert result["has_purchase"] is True
+    assert len(result["purchases"]) == 2
+
+    # Check first purchase
+    assert result["purchases"][0]["item_name"] == "BTC"
+    assert result["purchases"][0]["amount"] == 0.002
+    assert result["purchases"][0]["total_spent"] == 130.0
+
+    # Check second purchase
+    assert result["purchases"][1]["item_name"] == "ETH"
+    assert result["purchases"][1]["amount"] == 0.1
+    assert result["purchases"][1]["total_spent"] == 350.0
+
+def test_extract_binance_order_execution(mocker):
+    """Test extraction from Binance Order Execution Notice."""
+    email_content = EMAIL_FIXTURES["binance_order_execution"]
+
+    mock_llm_client = mocker.Mock()
+    mock_llm_client.generate_json.side_effect = [
+        # Classification
+        mocker.Mock(data={"is_crypto_purchase": True, "confidence": 0.95, "reasoning": "Order execution notice"}),
+        # Extraction
+        mocker.Mock(data={
+            "transactions": [
+                {
+                    "transaction_type": "buy",
+                    "total_spent": 900.0,
+                    "currency": "USDT",
+                    "amount": 5.0,
+                    "item_name": "SOL",
+                    "vendor": "Binance",
+                    "purchase_date": "2024-03-21 09:15:00",
+                    "transaction_id": "987654321",
+                    "confidence": 0.95,
+                }
+            ]
+        })
+    ]
+
+    settings = get_settings_with_overrides(enable_preprocessing=False)
+    extractor = EmailPurchaseExtractor(settings=settings, llm_client=mock_llm_client)
+
+    result = extractor.process_email(email_content)
+
+    assert result["has_purchase"] is True
+    assert len(result["purchases"]) == 1
+    assert result["purchases"][0]["item_name"] == "SOL"
+    assert result["purchases"][0]["amount"] == 5.0
+    assert result["purchases"][0]["transaction_id"] == "987654321"

--- a/tests/test_cli_v2.py
+++ b/tests/test_cli_v2.py
@@ -28,11 +28,13 @@ def test_process_emails_collects_metrics(mocker):
     mock_extractor = MagicMock()
     mock_extractor.process_email.return_value = {
         "has_purchase": True,
-        "purchase_info": {
-            "vendor": "Coinbase",
-            "currency": "USD",
-            "amount": 0.1,
-        },
+        "purchases": [
+            {
+                "vendor": "Coinbase",
+                "currency": "USD",
+                "amount": 0.1,
+            }
+        ],
         "processing_notes": [],
     }
 

--- a/tests/test_email_classification.py
+++ b/tests/test_email_classification.py
@@ -30,18 +30,22 @@ def test_process_email_purchase(extractor_factory):
             "reasoning": "The email contains keywords like 'purchase' and 'order'.",
         },
         {
-            "total_spent": 62.50,
-            "currency": "USD",
-            "amount": 2.5,
-            "item_name": "SOL",
-            "vendor": "Crypto Exchange",
-            "purchase_date": "2024-01-01T12:30:00Z",
+            "transactions": [
+                {
+                    "total_spent": 62.50,
+                    "currency": "USD",
+                    "amount": 2.5,
+                    "item_name": "SOL",
+                    "vendor": "Crypto Exchange",
+                    "purchase_date": "2024-01-01T12:30:00Z",
+                }
+            ]
         },
     ]
     extractor = extractor_factory(llm_responses)
     result = extractor.process_email(email_content)
     assert result["has_purchase"]
-    assert result["purchase_info"]["total_spent"] == 62.50
+    assert result["purchases"][0]["total_spent"] == 62.50
 
 
 def test_process_email_marketing(extractor_factory):
@@ -90,19 +94,23 @@ def test_process_email_gemini_purchase(extractor_factory):
             "reasoning": "Order confirmation from Gemini",
         },
         {
-            "total_spent": 150.0,
-            "currency": "USD",
-            "amount": 0.005,
-            "item_name": "BTC",
-            "vendor": "Gemini",
-            "purchase_date": "2024-01-15T00:00:00Z",
-            "transaction_id": "GEM-2024-001",
+            "transactions": [
+                {
+                    "total_spent": 150.0,
+                    "currency": "USD",
+                    "amount": 0.005,
+                    "item_name": "BTC",
+                    "vendor": "Gemini",
+                    "purchase_date": "2024-01-15T00:00:00Z",
+                    "transaction_id": "GEM-2024-001",
+                }
+            ]
         },
     ]
     extractor = extractor_factory(llm_responses)
     result = extractor.process_email(email_content)
     assert result["has_purchase"]
-    assert result["purchase_info"]["vendor"] == "Gemini"
+    assert result["purchases"][0]["vendor"] == "Gemini"
 
 
 def test_process_email_withdrawal_not_purchase(extractor_factory):
@@ -154,4 +162,3 @@ def test_process_email_newsletter(extractor_factory):
     extractor = extractor_factory(llm_responses)
     result = extractor.process_email(email_content)
     assert not result["has_purchase"]
-

--- a/tests/test_email_purchase_extractor.py
+++ b/tests/test_email_purchase_extractor.py
@@ -47,14 +47,18 @@ def test_extract_purchase_info_success(mocker):
     mock_llm_client = mocker.Mock()
     mock_llm_client.generate_json.return_value = mocker.Mock(
         data={
-            "total_spent": 500.0,
-            "currency": "USD",
-            "amount": 0.25,
-            "item_name": "ETH",
-            "vendor": "Binance",
-            "purchase_date": "2024-01-01 12:00:00",
-            "confidence": 0.9,
-            "extraction_notes": "",
+            "transactions": [
+                {
+                    "total_spent": 500.0,
+                    "currency": "USD",
+                    "amount": 0.25,
+                    "item_name": "ETH",
+                    "vendor": "Binance",
+                    "purchase_date": "2024-01-01 12:00:00",
+                    "confidence": 0.9,
+                    "extraction_notes": "",
+                }
+            ]
         }
     )
     from digital_asset_harvester.processing.email_purchase_extractor import (
@@ -64,7 +68,8 @@ def test_extract_purchase_info_success(mocker):
     settings = get_settings_with_overrides(enable_preprocessing=False)
     extractor = EmailPurchaseExtractor(settings=settings, llm_client=mock_llm_client)
     result = extractor.extract_purchase_info(email_content)
-    assert result == {
+    assert len(result) == 1
+    assert result[0] == {
         "total_spent": 500.0,
         "currency": "USD",
         "amount": 0.25,
@@ -82,20 +87,24 @@ def test_extract_purchase_info_missing_fields_strict(mocker):
     mock_llm_client = mocker.Mock()
     mock_llm_client.generate_json.return_value = mocker.Mock(
         data={
-            "total_spent": 500.0,
-            "currency": "USD",
-            "amount": 0.25,
-            "confidence": 0.9,
-            "extraction_notes": "",
+            "transactions": [
+                {
+                    "total_spent": 500.0,
+                    "currency": "USD",
+                    "amount": 0.25,
+                    "confidence": 0.9,
+                    "extraction_notes": "",
+                }
+            ]
         }
     )
     from digital_asset_harvester.processing.email_purchase_extractor import (
         EmailPurchaseExtractor,
     )
 
-    settings = get_settings_with_overrides(enable_preprocessing=False)
+    settings = get_settings_with_overrides(enable_preprocessing=False, strict_validation=True)
     extractor = EmailPurchaseExtractor(settings=settings, llm_client=mock_llm_client)
-    assert extractor.extract_purchase_info(email_content) is None
+    assert extractor.extract_purchase_info(email_content) == []
 
 
 def test_process_email_successful_path(mocker, monkeypatch):
@@ -111,14 +120,18 @@ def test_process_email_successful_path(mocker, monkeypatch):
         ),
         mocker.Mock(
             data={
-                "total_spent": 1000.0,
-                "currency": "USD",
-                "amount": 0.05,
-                "item_name": "BTC",
-                "vendor": "Coinbase",
-                "purchase_date": "2024-02-02 10:10:10",
-                "confidence": 0.9,
-                "extraction_notes": "",
+                "transactions": [
+                    {
+                        "total_spent": 1000.0,
+                        "currency": "USD",
+                        "amount": 0.05,
+                        "item_name": "BTC",
+                        "vendor": "Coinbase",
+                        "purchase_date": "2024-02-02 10:10:10",
+                        "confidence": 0.9,
+                        "extraction_notes": "",
+                    }
+                ]
             }
         ),
     ]
@@ -132,7 +145,8 @@ def test_process_email_successful_path(mocker, monkeypatch):
     monkeypatch.setattr(extractor, "_is_likely_purchase_related", lambda x: True)
     result = extractor.process_email(email_content)
     assert result["has_purchase"] is True
-    assert result["purchase_info"]["vendor"] == "Coinbase"
+    assert len(result["purchases"]) == 1
+    assert result["purchases"][0]["vendor"] == "Coinbase"
     assert "Successfully extracted" in result["processing_notes"][0]
 
 
@@ -149,6 +163,7 @@ def test_process_email_filtered_by_preprocessing(mocker):
     result = extractor.process_email(email_content)
     assert result == {
         "has_purchase": False,
+        "purchases": [],
         "processing_notes": ["Email not classified as crypto purchase"],
     }
 
@@ -166,14 +181,18 @@ def test_process_email_with_coinbase_fixture(mocker, monkeypatch):
         ),
         mocker.Mock(
             data={
-                "total_spent": 100.0,
-                "currency": "USD",
-                "amount": 0.001,
-                "item_name": "BTC",
-                "vendor": "Coinbase",
-                "purchase_date": "2024-01-01 12:00:00",
-                "confidence": 0.9,
-                "extraction_notes": "",
+                "transactions": [
+                    {
+                        "total_spent": 100.0,
+                        "currency": "USD",
+                        "amount": 0.001,
+                        "item_name": "BTC",
+                        "vendor": "Coinbase",
+                        "purchase_date": "2024-01-01 12:00:00",
+                        "confidence": 0.9,
+                        "extraction_notes": "",
+                    }
+                ]
             }
         ),
     ]
@@ -187,7 +206,7 @@ def test_process_email_with_coinbase_fixture(mocker, monkeypatch):
     monkeypatch.setattr(extractor, "_is_likely_purchase_related", lambda x: True)
     result = extractor.process_email(email_content)
     assert result["has_purchase"] is True
-    assert result["purchase_info"]["vendor"] == "Coinbase"
+    assert result["purchases"][0]["vendor"] == "Coinbase"
 
 
 def test_process_email_with_binance_fixture(mocker, monkeypatch):
@@ -203,14 +222,18 @@ def test_process_email_with_binance_fixture(mocker, monkeypatch):
         ),
         mocker.Mock(
             data={
-                "total_spent": 200.0,
-                "currency": "USD",
-                "amount": 0.1,
-                "item_name": "ETH",
-                "vendor": "Binance",
-                "purchase_date": "2024-01-02 12:00:00",
-                "confidence": 0.9,
-                "extraction_notes": "",
+                "transactions": [
+                    {
+                        "total_spent": 200.0,
+                        "currency": "USD",
+                        "amount": 0.1,
+                        "item_name": "ETH",
+                        "vendor": "Binance",
+                        "purchase_date": "2024-01-02 12:00:00",
+                        "confidence": 0.9,
+                        "extraction_notes": "",
+                    }
+                ]
             }
         ),
     ]
@@ -224,7 +247,7 @@ def test_process_email_with_binance_fixture(mocker, monkeypatch):
     monkeypatch.setattr(extractor, "_is_likely_purchase_related", lambda x: True)
     result = extractor.process_email(email_content)
     assert result["has_purchase"] is True
-    assert result["purchase_info"]["vendor"] == "Binance"
+    assert result["purchases"][0]["vendor"] == "Binance"
 
 
 def test_process_email_with_non_purchase_fixture(mocker, monkeypatch):
@@ -262,15 +285,19 @@ def test_process_email_with_binance_deposit_fixture(mocker, monkeypatch):
         ),
         mocker.Mock(
             data={
-                "transaction_type": "deposit",
-                "total_spent": None,
-                "currency": None,
-                "amount": 0.1,
-                "item_name": "BTC",
-                "vendor": "Binance",
-                "purchase_date": "2024-01-02 12:00:00",
-                "confidence": 0.9,
-                "extraction_notes": "",
+                "transactions": [
+                    {
+                        "transaction_type": "deposit",
+                        "total_spent": None,
+                        "currency": None,
+                        "amount": 0.1,
+                        "item_name": "BTC",
+                        "vendor": "Binance",
+                        "purchase_date": "2024-01-02 12:00:00",
+                        "confidence": 0.9,
+                        "extraction_notes": "",
+                    }
+                ]
             }
         ),
     ]
@@ -284,9 +311,9 @@ def test_process_email_with_binance_deposit_fixture(mocker, monkeypatch):
     monkeypatch.setattr(extractor, "_is_likely_purchase_related", lambda x: True)
     result = extractor.process_email(email_content)
     assert result["has_purchase"] is True
-    assert result["purchase_info"]["vendor"] == "Binance"
-    assert result["purchase_info"]["amount"] == 0.1
-    assert result["purchase_info"]["item_name"] == "BTC"
+    assert result["purchases"][0]["vendor"] == "Binance"
+    assert result["purchases"][0]["amount"] == 0.1
+    assert result["purchases"][0]["item_name"] == "BTC"
 
 
 def test_process_email_with_binance_withdrawal_fixture(mocker, monkeypatch):
@@ -302,15 +329,19 @@ def test_process_email_with_binance_withdrawal_fixture(mocker, monkeypatch):
         ),
         mocker.Mock(
             data={
-                "transaction_type": "withdrawal",
-                "total_spent": None,
-                "currency": None,
-                "amount": 0.5,
-                "item_name": "ETH",
-                "vendor": "Binance",
-                "purchase_date": "2024-01-02 12:00:00",
-                "confidence": 0.9,
-                "extraction_notes": "",
+                "transactions": [
+                    {
+                        "transaction_type": "withdrawal",
+                        "total_spent": None,
+                        "currency": None,
+                        "amount": 0.5,
+                        "item_name": "ETH",
+                        "vendor": "Binance",
+                        "purchase_date": "2024-01-02 12:00:00",
+                        "confidence": 0.9,
+                        "extraction_notes": "",
+                    }
+                ]
             }
         ),
     ]
@@ -324,9 +355,9 @@ def test_process_email_with_binance_withdrawal_fixture(mocker, monkeypatch):
     monkeypatch.setattr(extractor, "_is_likely_purchase_related", lambda x: True)
     result = extractor.process_email(email_content)
     assert result["has_purchase"] is True
-    assert result["purchase_info"]["vendor"] == "Binance"
-    assert result["purchase_info"]["amount"] == 0.5
-    assert result["purchase_info"]["item_name"] == "ETH"
+    assert result["purchases"][0]["vendor"] == "Binance"
+    assert result["purchases"][0]["amount"] == 0.5
+    assert result["purchases"][0]["item_name"] == "ETH"
 
 
 def test_process_email_with_coinbase_staking_reward(mocker, monkeypatch):
@@ -342,16 +373,20 @@ def test_process_email_with_coinbase_staking_reward(mocker, monkeypatch):
         ),
         mocker.Mock(
             data={
-                "transaction_type": "staking_reward",
-                "total_spent": None,
-                "currency": None,
-                "amount": 0.00001234,
-                "item_name": "ETH",
-                "vendor": "Coinbase",
-                "purchase_date": "2025-01-01 12:00:00",
-                "transaction_id": "CB-STAKE-2025-ABC",
-                "confidence": 0.9,
-                "extraction_notes": "",
+                "transactions": [
+                    {
+                        "transaction_type": "staking_reward",
+                        "total_spent": None,
+                        "currency": None,
+                        "amount": 0.00001234,
+                        "item_name": "ETH",
+                        "vendor": "Coinbase",
+                        "purchase_date": "2025-01-01 12:00:00",
+                        "transaction_id": "CB-STAKE-2025-ABC",
+                        "confidence": 0.9,
+                        "extraction_notes": "",
+                    }
+                ]
             }
         ),
     ]
@@ -365,9 +400,9 @@ def test_process_email_with_coinbase_staking_reward(mocker, monkeypatch):
     monkeypatch.setattr(extractor, "_is_likely_purchase_related", lambda x: True)
     result = extractor.process_email(email_content)
     assert result["has_purchase"] is True
-    assert result["purchase_info"]["transaction_type"] == "staking_reward"
-    assert result["purchase_info"]["amount"] == 0.00001234
-    assert result["purchase_info"]["transaction_id"] == "CB-STAKE-2025-ABC"
+    assert result["purchases"][0]["transaction_type"] == "staking_reward"
+    assert result["purchases"][0]["amount"] == 0.00001234
+    assert result["purchases"][0]["transaction_id"] == "CB-STAKE-2025-ABC"
 
 
 def test_process_email_with_binance_staking_reward(mocker, monkeypatch):
@@ -383,16 +418,20 @@ def test_process_email_with_binance_staking_reward(mocker, monkeypatch):
         ),
         mocker.Mock(
             data={
-                "transaction_type": "staking_reward",
-                "total_spent": None,
-                "currency": None,
-                "amount": 0.5,
-                "item_name": "SOL",
-                "vendor": "Binance",
-                "purchase_date": "2025-01-01 12:00:00",
-                "transaction_id": "BIN-STAKE-2025-XYZ",
-                "confidence": 0.9,
-                "extraction_notes": "",
+                "transactions": [
+                    {
+                        "transaction_type": "staking_reward",
+                        "total_spent": None,
+                        "currency": None,
+                        "amount": 0.5,
+                        "item_name": "SOL",
+                        "vendor": "Binance",
+                        "purchase_date": "2025-01-01 12:00:00",
+                        "transaction_id": "BIN-STAKE-2025-XYZ",
+                        "confidence": 0.9,
+                        "extraction_notes": "",
+                    }
+                ]
             }
         ),
     ]
@@ -406,9 +445,9 @@ def test_process_email_with_binance_staking_reward(mocker, monkeypatch):
     monkeypatch.setattr(extractor, "_is_likely_purchase_related", lambda x: True)
     result = extractor.process_email(email_content)
     assert result["has_purchase"] is True
-    assert result["purchase_info"]["transaction_type"] == "staking_reward"
-    assert result["purchase_info"]["amount"] == 0.5
-    assert result["purchase_info"]["transaction_id"] == "BIN-STAKE-2025-XYZ"
+    assert result["purchases"][0]["transaction_type"] == "staking_reward"
+    assert result["purchases"][0]["amount"] == 0.5
+    assert result["purchases"][0]["transaction_id"] == "BIN-STAKE-2025-XYZ"
 
 
 def test_process_email_with_kraken_staking_reward(mocker, monkeypatch):
@@ -424,16 +463,20 @@ def test_process_email_with_kraken_staking_reward(mocker, monkeypatch):
         ),
         mocker.Mock(
             data={
-                "transaction_type": "staking_reward",
-                "total_spent": None,
-                "currency": None,
-                "amount": 10.5,
-                "item_name": "ADA",
-                "vendor": "Kraken",
-                "purchase_date": "2025-01-01 12:00:00",
-                "transaction_id": "KR-STAKE-2025-999",
-                "confidence": 0.9,
-                "extraction_notes": "",
+                "transactions": [
+                    {
+                        "transaction_type": "staking_reward",
+                        "total_spent": None,
+                        "currency": None,
+                        "amount": 10.5,
+                        "item_name": "ADA",
+                        "vendor": "Kraken",
+                        "purchase_date": "2025-01-01 12:00:00",
+                        "transaction_id": "KR-STAKE-2025-999",
+                        "confidence": 0.9,
+                        "extraction_notes": "",
+                    }
+                ]
             }
         ),
     ]
@@ -447,6 +490,6 @@ def test_process_email_with_kraken_staking_reward(mocker, monkeypatch):
     monkeypatch.setattr(extractor, "_is_likely_purchase_related", lambda x: True)
     result = extractor.process_email(email_content)
     assert result["has_purchase"] is True
-    assert result["purchase_info"]["transaction_type"] == "staking_reward"
-    assert result["purchase_info"]["amount"] == 10.5
-    assert result["purchase_info"]["transaction_id"] == "KR-STAKE-2025-999"
+    assert result["purchases"][0]["transaction_type"] == "staking_reward"
+    assert result["purchases"][0]["amount"] == 10.5
+    assert result["purchases"][0]["transaction_id"] == "KR-STAKE-2025-999"

--- a/tests/test_extraction_logic.py
+++ b/tests/test_extraction_logic.py
@@ -8,36 +8,40 @@ def test_extract_purchase_info_coinbase(extractor_factory):
     email_content = EMAIL_FIXTURES["coinbase_purchase"]
     llm_responses = [
         {
-            "total_spent": 100.0,
-            "currency": "USD",
-            "amount": 0.001,
-            "item_name": "BTC",
-            "vendor": "Coinbase",
-            "purchase_date": "2024-01-01 12:00:00",
-            "confidence": 0.9,
+            "transactions": [
+                {
+                    "total_spent": 100.0,
+                    "currency": "USD",
+                    "amount": 0.001,
+                    "item_name": "BTC",
+                    "vendor": "Coinbase",
+                    "purchase_date": "2024-01-01 12:00:00",
+                    "confidence": 0.9,
+                }
+            ]
         }
     ]
     extractor = extractor_factory(llm_responses)
     result = extractor.extract_purchase_info(email_content)
 
-    assert result
-    assert result["total_spent"] == 100.0
-    assert result["currency"] == "USD"
-    assert result["amount"] == 0.001
-    assert result["item_name"] == "BTC"
-    assert result["vendor"] == "Coinbase"
-    assert result["purchase_date"] == "2024-01-01 12:00:00 UTC"
+    assert len(result) == 1
+    assert result[0]["total_spent"] == 100.0
+    assert result[0]["currency"] == "USD"
+    assert result[0]["amount"] == 0.001
+    assert result[0]["item_name"] == "BTC"
+    assert result[0]["vendor"] == "Coinbase"
+    assert result[0]["purchase_date"] == "2024-01-01 12:00:00 UTC"
 
 
 def test_extract_purchase_info_extraction_fails(extractor_factory):
     """
-    Tests that extract_purchase_info returns None when extraction fails.
+    Tests that extract_purchase_info returns empty list when extraction fails.
     """
     email_content = EMAIL_FIXTURES["binance_purchase"]
     llm_responses = [{"error": "extraction failed"}]
     extractor = extractor_factory(llm_responses)
     result = extractor.extract_purchase_info(email_content)
-    assert result is None
+    assert result == []
 
 
 def test_extract_purchase_info_binance(extractor_factory):
@@ -47,22 +51,26 @@ def test_extract_purchase_info_binance(extractor_factory):
     email_content = EMAIL_FIXTURES["binance_purchase"]
     llm_responses = [
         {
-            "total_spent": 200.0,
-            "currency": "USD",
-            "amount": 0.1,
-            "item_name": "ETH",
-            "vendor": "Binance",
-            "purchase_date": "2024-01-01 12:00:00",
+            "transactions": [
+                {
+                    "total_spent": 200.0,
+                    "currency": "USD",
+                    "amount": 0.1,
+                    "item_name": "ETH",
+                    "vendor": "Binance",
+                    "purchase_date": "2024-01-01 12:00:00",
+                }
+            ]
         }
     ]
     extractor = extractor_factory(llm_responses)
     result = extractor.extract_purchase_info(email_content)
 
-    assert result
-    assert result["total_spent"] == 200.0
-    assert result["amount"] == 0.1
-    assert result["item_name"] == "ETH"
-    assert result["vendor"] == "Binance"
+    assert len(result) == 1
+    assert result[0]["total_spent"] == 200.0
+    assert result[0]["amount"] == 0.1
+    assert result[0]["item_name"] == "ETH"
+    assert result[0]["vendor"] == "Binance"
 
 
 def test_extract_purchase_info_kraken(extractor_factory):
@@ -72,21 +80,25 @@ def test_extract_purchase_info_kraken(extractor_factory):
     email_content = EMAIL_FIXTURES["kraken_purchase"]
     llm_responses = [
         {
-            "total_spent": 50.0,
-            "currency": "EUR",
-            "amount": 0.5,
-            "item_name": "XMR",
-            "vendor": "Kraken",
-            "purchase_date": "2024-01-01 12:00:00",
+            "transactions": [
+                {
+                    "total_spent": 50.0,
+                    "currency": "EUR",
+                    "amount": 0.5,
+                    "item_name": "XMR",
+                    "vendor": "Kraken",
+                    "purchase_date": "2024-01-01 12:00:00",
+                }
+            ]
         }
     ]
     extractor = extractor_factory(llm_responses)
     result = extractor.extract_purchase_info(email_content)
 
-    assert result
-    assert result["currency"] == "EUR"
-    assert result["item_name"] == "XMR"
-    assert result["vendor"] == "Kraken"
+    assert len(result) == 1
+    assert result[0]["currency"] == "EUR"
+    assert result[0]["item_name"] == "XMR"
+    assert result[0]["vendor"] == "Kraken"
 
 
 def test_extract_purchase_info_gemini(extractor_factory):
@@ -96,22 +108,26 @@ def test_extract_purchase_info_gemini(extractor_factory):
     email_content = EMAIL_FIXTURES["gemini_purchase"]
     llm_responses = [
         {
-            "total_spent": 150.0,
-            "currency": "USD",
-            "amount": 0.005,
-            "item_name": "BTC",
-            "vendor": "Gemini",
-            "purchase_date": "2024-01-15",
-            "transaction_id": "GEM-2024-001",
+            "transactions": [
+                {
+                    "total_spent": 150.0,
+                    "currency": "USD",
+                    "amount": 0.005,
+                    "item_name": "BTC",
+                    "vendor": "Gemini",
+                    "purchase_date": "2024-01-15",
+                    "transaction_id": "GEM-2024-001",
+                }
+            ]
         }
     ]
     extractor = extractor_factory(llm_responses)
     result = extractor.extract_purchase_info(email_content)
 
-    assert result
-    assert result["vendor"] == "Gemini"
-    assert "transaction_id" in result
-    assert result["transaction_id"] == "GEM-2024-001"
+    assert len(result) == 1
+    assert result[0]["vendor"] == "Gemini"
+    assert "transaction_id" in result[0]
+    assert result[0]["transaction_id"] == "GEM-2024-001"
 
 
 def test_extract_purchase_info_ftx(extractor_factory):
@@ -121,21 +137,25 @@ def test_extract_purchase_info_ftx(extractor_factory):
     email_content = EMAIL_FIXTURES["ftx_purchase"]
     llm_responses = [
         {
-            "total_spent": 8.50,
-            "currency": "USD",
-            "amount": 10,
-            "item_name": "MATIC",
-            "vendor": "FTX",
-            "purchase_date": "2024-01-01",
+            "transactions": [
+                {
+                    "total_spent": 8.50,
+                    "currency": "USD",
+                    "amount": 10,
+                    "item_name": "MATIC",
+                    "vendor": "FTX",
+                    "purchase_date": "2024-01-01",
+                }
+            ]
         }
     ]
     extractor = extractor_factory(llm_responses)
     result = extractor.extract_purchase_info(email_content)
 
-    assert result
-    assert result["amount"] == 10
-    assert result["item_name"] == "MATIC"
-    assert result["total_spent"] == 8.50
+    assert len(result) == 1
+    assert result[0]["amount"] == 10
+    assert result[0]["item_name"] == "MATIC"
+    assert result[0]["total_spent"] == 8.50
 
 
 def test_extract_purchase_info_partial_data(extractor_factory):
@@ -145,15 +165,18 @@ def test_extract_purchase_info_partial_data(extractor_factory):
     email_content = EMAIL_FIXTURES["partial_data_purchase"]
     llm_responses = [
         {
-            "amount": 1.5,
-            "item_name": "LTC",
-            "vendor": "Unknown Exchange",
+            "transactions": [
+                {
+                    "amount": 1.5,
+                    "item_name": "LTC",
+                    "vendor": "Unknown Exchange",
+                }
+            ]
         }
     ]
     extractor = extractor_factory(llm_responses)
     result = extractor.extract_purchase_info(email_content)
 
     # With strict validation disabled or handling missing fields
-    # Result might be None or contain partial data
-    assert result is None or isinstance(result, dict)
-
+    # Result might be empty or contain partial data
+    assert isinstance(result, list)


### PR DESCRIPTION
This PR enhances the accuracy and capability of the extraction logic for Binance emails. 

Key changes:
1. **Multi-asset support**: Binance "Trade Confirmation" emails often contain multiple fills. The extraction architecture has been updated from a single-purchase model to a multi-purchase model by changing the LLM prompt to return an array of transactions and updating the processing pipeline to handle them.
2. **Improved Prompts**: Added specific instructions and examples for Binance formats, including how to handle trading pairs and multi-asset lists.
3. **Keyword Expansion**: Added "trade confirmation" and "order execution" to the purchase-related keywords to improve classification of Binance emails.
4. **Validation Improvement**: Updated the currency validation regex to support up to 5 characters, allowing symbols like USDT and USDC which are common in exchange emails.
5. **Comprehensive Testing**: Added new test cases specifically for Binance multi-asset emails and updated all existing tests to match the new internal data structures.

Verified through unit tests, manual fixture testing, and a full regression run of the test suite.

Fixes #130

---
*PR created automatically by Jules for task [6470756425443550478](https://jules.google.com/task/6470756425443550478) started by @username-anthony-is-not-available*