### PR TITLE
[Security] Implement PII Scrubber before LLM processing

### DIFF
--- a/digital_asset_harvester/config.py
+++ b/digital_asset_harvester/config.py
@@ -34,6 +34,7 @@ class HarvesterSettings:
 	anthropic_model_name: str = "claude-3-sonnet-20240229"
 
 	enable_preprocessing: bool = True
+	enable_pii_scrubbing: bool = False
 	enable_regex_extractors: bool = True
 	enable_validation: bool = True
 	min_confidence_threshold: float = 0.6

--- a/digital_asset_harvester/utils/pii_scrubber.py
+++ b/digital_asset_harvester/utils/pii_scrubber.py
@@ -1,0 +1,112 @@
+"""Utility for scrubbing Personally Identifiable Information (PII) from text."""
+
+from __future__ import annotations
+
+import logging
+import regex as re
+from typing import Set, Optional
+
+logger = logging.getLogger(__name__)
+
+class PIIScrubber:
+    """Detects and masks PII in text using regular expressions."""
+
+    def __init__(self, skip_terms: Optional[Set[str]] = None):
+        """
+        Initialize the scrubber.
+
+        Args:
+            skip_terms: A set of terms that should not be masked even if they
+                match a PII pattern (e.g., crypto currency names).
+        """
+        self.skip_terms = {term.lower() for term in (skip_terms or set())}
+
+        # Email addresses
+        self.email_re = re.compile(
+            r'[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}',
+            re.IGNORECASE
+        )
+
+        # Phone numbers (broad pattern)
+        self.phone_re = re.compile(
+            r'(\+?\d{1,3}[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4,6}',
+            re.IGNORECASE
+        )
+
+        # IP Addresses (IPv4)
+        self.ip_re = re.compile(
+            r'\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b'
+        )
+
+        # Credit Card Numbers
+        self.cc_re = re.compile(
+            r'\b\d{4}[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{4}\b'
+        )
+
+        # Physical Addresses (Heuristic)
+        # Matches: Number + Street Name + Suffix (St, Ave, etc.)
+        self.address_re = re.compile(
+            r'\b\d{1,5}\s+[A-Z][a-z]+(?:\s+[A-Z][a-z]+)*\s+'
+            r'(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Drive|Dr|Lane|Ln|Court|Ct|Circle|Cir|Way)',
+            re.IGNORECASE
+        )
+
+        # Name patterns (Heuristic)
+        # Matches: Hi/Dear/Hello followed by 1-3 capitalized words
+        self.name_greeting_re = re.compile(
+            r'\b(Hi|Dear|Hello|Greetings)\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+){0,2})',
+            re.MULTILINE
+        )
+
+    def _should_mask(self, match_text: str) -> bool:
+        """Check if the matched text should actually be masked."""
+        return match_text.lower() not in self.skip_terms
+
+    def scrub(self, text: str) -> str:
+        """
+        Mask PII in the given text.
+
+        Args:
+            text: The text to scrub.
+
+        Returns:
+            The scrubbed text with PII masked by placeholders.
+        """
+        if not text:
+            return text
+
+        # Scrub emails
+        text = self.email_re.sub(
+            lambda m: "[EMAIL]" if self._should_mask(m.group(0)) else m.group(0),
+            text
+        )
+
+        # Scrub phone numbers
+        text = self.phone_re.sub(
+            lambda m: "[PHONE]" if self._should_mask(m.group(0)) else m.group(0),
+            text
+        )
+
+        # Scrub IP addresses
+        text = self.ip_re.sub("[IP_ADDRESS]", text)
+
+        # Scrub credit cards
+        text = self.cc_re.sub("[CREDIT_CARD]", text)
+
+        # Scrub addresses
+        text = self.address_re.sub(
+            lambda m: "[ADDRESS]" if self._should_mask(m.group(0)) else m.group(0),
+            text
+        )
+
+        # Scrub names in greetings
+        def mask_name(match):
+            greeting = match.group(1)
+            name = match.group(2)
+            if self._should_mask(name):
+                return f"{greeting} [NAME]"
+            return match.group(0)
+
+        text = self.name_greeting_re.sub(mask_name, text)
+
+        return text

--- a/tests/test_pii_integration.py
+++ b/tests/test_pii_integration.py
@@ -1,0 +1,77 @@
+"""Integration tests for PII scrubbing in EmailPurchaseExtractor."""
+
+import pytest
+from digital_asset_harvester.processing.email_purchase_extractor import EmailPurchaseExtractor
+from digital_asset_harvester.config import get_settings_with_overrides
+
+def test_pii_scrubbing_integration(mocker):
+    # Setup
+    email_content = (
+        "Subject: Your purchase from Coinbase\n"
+        "From: no-reply@coinbase.com\n"
+        "Body: Hi John Doe, you bought 0.1 BTC. "
+        "It was shipped to 123 Main St. "
+        "Contact us at support@coinbase.com or 555-555-1234."
+    )
+
+    mock_llm_client = mocker.Mock()
+    # Mock return values for both classification and extraction
+    mock_llm_client.generate_json.side_effect = [
+        mocker.Mock(data={"is_crypto_purchase": True, "confidence": 0.9, "reasoning": "Test"}),
+        mocker.Mock(data={"transactions": [{"item_name": "BTC", "amount": 0.1, "vendor": "Coinbase", "total_spent": 100, "currency": "USD", "purchase_date": "2024-01-01", "confidence": 0.9}]})
+    ]
+
+    # Enable PII scrubbing
+    settings = get_settings_with_overrides(
+        enable_pii_scrubbing=True,
+        enable_preprocessing=False,  # Skip preprocessing to focus on LLM call
+        enable_regex_extractors=False # Force LLM fallback
+    )
+
+    extractor = EmailPurchaseExtractor(settings=settings, llm_client=mock_llm_client)
+
+    # Execute
+    extractor.process_email(email_content)
+
+    # Verify
+    # Check that generate_json was called twice (classification and extraction)
+    assert mock_llm_client.generate_json.call_count == 2
+
+    for call in mock_llm_client.generate_json.call_args_list:
+        prompt = call.args[0]
+        # Verify that PII is masked in the prompt
+        assert "[NAME]" in prompt
+        assert "[ADDRESS]" in prompt
+        assert "[EMAIL]" in prompt
+        assert "[PHONE]" in prompt
+
+        # Verify that original PII is NOT in the prompt
+        assert "John Doe" not in prompt
+        assert "123 Main St" not in prompt
+        assert "support@coinbase.com" not in prompt
+        assert "555-555-1234" not in prompt
+
+        # Verify that transaction data is STILL in the prompt
+        assert "0.1" in prompt
+        assert "BTC" in prompt
+        assert "Coinbase" in prompt
+
+def test_pii_scrubbing_disabled_by_default(mocker):
+    # Setup
+    email_content = "Body: Hi John Doe, you bought 0.1 BTC."
+    mock_llm_client = mocker.Mock()
+    mock_llm_client.generate_json.return_value = mocker.Mock(data={"is_crypto_purchase": True, "confidence": 0.9})
+
+    # Default settings (PII scrubbing should be False)
+    settings = get_settings_with_overrides(enable_preprocessing=False)
+    assert settings.enable_pii_scrubbing is False
+
+    extractor = EmailPurchaseExtractor(settings=settings, llm_client=mock_llm_client)
+
+    # Execute
+    extractor.is_crypto_purchase_email(email_content)
+
+    # Verify
+    prompt = mock_llm_client.generate_json.call_args.args[0]
+    assert "John Doe" in prompt
+    assert "[NAME]" not in prompt

--- a/tests/test_pii_scrubber.py
+++ b/tests/test_pii_scrubber.py
@@ -1,0 +1,85 @@
+"""Unit tests for the PIIScrubber utility."""
+
+import pytest
+from digital_asset_harvester.utils.pii_scrubber import PIIScrubber
+
+def test_scrub_email():
+    scrubber = PIIScrubber()
+    text = "Contact me at john.doe@example.com for more info."
+    expected = "Contact me at [EMAIL] for more info."
+    assert scrubber.scrub(text) == expected
+
+def test_scrub_phone():
+    scrubber = PIIScrubber()
+    text = "My phone number is +1-555-010-9999."
+    expected = "My phone number is [PHONE]."
+    assert scrubber.scrub(text) == expected
+
+def test_scrub_ip():
+    scrubber = PIIScrubber()
+    text = "Login from IP 192.168.1.1 detected."
+    expected = "Login from IP [IP_ADDRESS] detected."
+    assert scrubber.scrub(text) == expected
+
+def test_scrub_credit_card():
+    scrubber = PIIScrubber()
+    text = "Card number: 1234-5678-9012-3456."
+    expected = "Card number: [CREDIT_CARD]."
+    assert scrubber.scrub(text) == expected
+
+def test_scrub_address():
+    scrubber = PIIScrubber()
+    text = "Ship to 123 Main Street, Springfield."
+    expected = "Ship to [ADDRESS], Springfield."
+    assert scrubber.scrub(text) == expected
+
+    text = "Visit us at 456 Broadway Ave."
+    expected = "Visit us at [ADDRESS]."
+    assert scrubber.scrub(text) == expected
+
+def test_scrub_name_greeting():
+    scrubber = PIIScrubber()
+    text = "Hi John Doe,\nYour order is ready."
+    expected = "Hi [NAME],\nYour order is ready."
+    assert scrubber.scrub(text) == expected
+
+    text = "Dear Alice Smith,\nWelcome back."
+    expected = "Dear [NAME],\nWelcome back."
+    assert scrubber.scrub(text) == expected
+
+def test_skip_terms():
+    # Test that terms in skip_terms are NOT masked
+    scrubber = PIIScrubber(skip_terms={"Bitcoin", "Coinbase"})
+
+    # "Bitcoin" shouldn't be masked by name greeting if it happened to match (unlikely but testable)
+    text = "Hi Bitcoin,"
+    assert scrubber.scrub(text) == "Hi Bitcoin,"
+
+    # "coinbase@example.com" should still be masked if we match the whole email,
+    # but let's see how _should_mask works.
+    # In my implementation, I pass the whole match to _should_mask.
+    text = "Contact support@coinbase.com"
+    assert scrubber.scrub(text) == "Contact [EMAIL]"
+
+    # If I add the exact email to skip_terms
+    scrubber = PIIScrubber(skip_terms={"support@coinbase.com"})
+    assert scrubber.scrub(text) == "Contact support@coinbase.com"
+
+def test_scrub_empty_text():
+    scrubber = PIIScrubber()
+    assert scrubber.scrub("") == ""
+    assert scrubber.scrub(None) is None
+
+def test_multiple_pii():
+    scrubber = PIIScrubber()
+    text = "Hi John, send $100 to 123 Main St or email me at john@doe.com."
+    # Note: 123 Main St matches address heuristic
+    # john@doe.com matches email
+    # Hi John matches name greeting
+    scrubbed = scrubber.scrub(text)
+    assert "[NAME]" in scrubbed
+    assert "[ADDRESS]" in scrubbed
+    assert "[EMAIL]" in scrubbed
+    assert "John" not in scrubbed
+    assert "123 Main St" not in scrubbed
+    assert "john@doe.com" not in scrubbed


### PR DESCRIPTION
This change implements a PII Scrubber that removes personally identifiable information (PII) from email content before it is sent to an external LLM (like OpenAI or Anthropic). 

Key changes:
1. **Configuration**: A new `enable_pii_scrubbing` flag (default `False`) in `HarvesterSettings`.
2. **PII Scrubber**: A robust utility using regex to mask email addresses, phone numbers, IP addresses, credit card numbers, physical addresses, and names in greetings. It includes a `skip_terms` feature to avoid masking cryptocurrency names or exchange names.
3. **Integration**: The `EmailPurchaseExtractor` now automatically scrubs PII from email content before rendering prompts for LLM-based tasks, provided the feature is enabled.
4. **Testing**: 
    - Unit tests in `tests/test_pii_scrubber.py` verify the regex patterns and masking logic.
    - Integration tests in `tests/test_pii_integration.py` verify that the scrubber is correctly invoked and that sensitive data is masked in the actual prompts sent to the LLM client.
5. **Fixes**: Installed `toml` to fix pre-existing configuration test failures.

Fixes #106

---
*PR created automatically by Jules for task [14680788588007845204](https://jules.google.com/task/14680788588007845204) started by @username-anthony-is-not-available*