### PR TITLE
Implement Ollama automatic fallback to Cloud LLM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Ollama Auto-Fallback**: Automatic fallback to Cloud LLM if local Ollama is too slow.
+  - New `FallbackLLMClient` to handle provider switching.
+  - Configuration options: `enable_ollama_fallback`, `ollama_fallback_threshold_seconds`, `fallback_cloud_provider`.
+  - Seamless integration with existing `get_llm_client` factory.
+
 - **Koinly CSV Export**: Added support for exporting transactions in Koinly Universal CSV format
   - New `KoinlyReportGenerator` class for generating Koinly-compatible CSV files
   - `write_purchase_data_to_koinly_csv()` function for easy CSV export

--- a/README.md
+++ b/README.md
@@ -188,6 +188,16 @@ In addition to the default local LLM (Ollama), the harvester now supports cloud-
   - `DAP_OPENAI_API_KEY`
   - `DAP_ANTHROPIC_API_KEY`
 
+#### Ollama Auto-Fallback
+
+If you have a slow computer and local Ollama processing takes too long, you can enable automatic fallback to a cloud provider.
+
+- **Enable Fallback**: Set `DAP_ENABLE_OLLAMA_FALLBACK=true`.
+- **Threshold**: Set the timeout threshold in seconds using `DAP_OLLAMA_FALLBACK_THRESHOLD_SECONDS` (default: 10).
+- **Cloud Provider**: Specify the fallback cloud provider with `DAP_FALLBACK_CLOUD_PROVIDER` (default: `openai`).
+
+When enabled, if Ollama takes longer than the threshold, the harvester will automatically switch to the configured cloud provider for that email.
+
 Example configuration:
 
 ```sh

--- a/digital_asset_harvester/config.py
+++ b/digital_asset_harvester/config.py
@@ -26,6 +26,9 @@ class HarvesterSettings:
 
 	enable_cloud_llm: bool = False
 	llm_provider: str = "ollama"
+	enable_ollama_fallback: bool = False
+	ollama_fallback_threshold_seconds: int = 10
+	fallback_cloud_provider: str = "openai"
 
 	openai_api_key: str = ""
 	openai_model_name: str = "gpt-4-turbo-preview"

--- a/digital_asset_harvester/llm/fallback_client.py
+++ b/digital_asset_harvester/llm/fallback_client.py
@@ -1,0 +1,46 @@
+"""Fallback LLM provider that switches to a secondary provider if the primary fails."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from .ollama_client import LLMError
+from .provider import LLMProvider, LLMResult
+
+logger = logging.getLogger(__name__)
+
+
+class FallbackLLMClient(LLMProvider):
+    """LLM provider that tries a primary provider and falls back to a secondary one on failure."""
+
+    def __init__(
+        self,
+        primary: LLMProvider,
+        secondary: LLMProvider,
+        name: str = "FallbackClient",
+    ) -> None:
+        self.primary = primary
+        self.secondary = secondary
+        self.name = name
+
+    def generate_json(
+        self,
+        prompt: str,
+        *,
+        model: Optional[str] = None,
+        retries: Optional[int] = None,
+        temperature: Optional[float] = None,
+    ) -> LLMResult:
+        try:
+            logger.info("Trying primary LLM provider...")
+            return self.primary.generate_json(
+                prompt, model=model, retries=retries, temperature=temperature
+            )
+        except (LLMError, Exception) as exc:
+            logger.warning(
+                "Primary LLM provider failed, falling back to secondary: %s", exc
+            )
+            return self.secondary.generate_json(
+                prompt, model=model, retries=retries, temperature=temperature
+            )

--- a/tests/llm/test_fallback_client.py
+++ b/tests/llm/test_fallback_client.py
@@ -1,0 +1,90 @@
+
+import pytest
+from unittest.mock import MagicMock, patch
+from digital_asset_harvester.llm.fallback_client import FallbackLLMClient
+from digital_asset_harvester.llm.provider import LLMResult
+from digital_asset_harvester.llm.ollama_client import LLMError
+from digital_asset_harvester.llm import get_llm_client
+from digital_asset_harvester.config import HarvesterSettings
+
+def test_fallback_client_success_primary():
+    primary = MagicMock()
+    secondary = MagicMock()
+    client = FallbackLLMClient(primary, secondary)
+
+    expected_result = LLMResult(data={"key": "value"}, raw_text='{"key": "value"}')
+    primary.generate_json.return_value = expected_result
+
+    result = client.generate_json("test prompt")
+
+    assert result == expected_result
+    primary.generate_json.assert_called_once()
+    secondary.generate_json.assert_not_called()
+
+def test_fallback_client_fallback_on_llmerror():
+    primary = MagicMock()
+    secondary = MagicMock()
+    client = FallbackLLMClient(primary, secondary)
+
+    primary.generate_json.side_effect = LLMError("Primary failed")
+    expected_result = LLMResult(data={"key": "fallback"}, raw_text='{"key": "fallback"}')
+    secondary.generate_json.return_value = expected_result
+
+    result = client.generate_json("test prompt")
+
+    assert result == expected_result
+    primary.generate_json.assert_called_once()
+    secondary.generate_json.assert_called_once()
+
+def test_fallback_client_fallback_on_exception():
+    primary = MagicMock()
+    secondary = MagicMock()
+    client = FallbackLLMClient(primary, secondary)
+
+    primary.generate_json.side_effect = Exception("Unexpected error")
+    expected_result = LLMResult(data={"key": "fallback"}, raw_text='{"key": "fallback"}')
+    secondary.generate_json.return_value = expected_result
+
+    result = client.generate_json("test prompt")
+
+    assert result == expected_result
+    primary.generate_json.assert_called_once()
+    secondary.generate_json.assert_called_once()
+
+@patch("digital_asset_harvester.llm.get_settings")
+@patch("digital_asset_harvester.llm.ollama_client.OllamaLLMClient")
+@patch("digital_asset_harvester.llm.openai_client.OpenAILLMClient")
+@patch("digital_asset_harvester.llm.fallback_client.FallbackLLMClient")
+def test_get_llm_client_returns_fallback(mock_fallback, mock_openai, mock_ollama, mock_get_settings):
+    # Setup settings
+    settings = HarvesterSettings(
+        llm_provider="ollama",
+        enable_ollama_fallback=True,
+        enable_cloud_llm=True,
+        ollama_fallback_threshold_seconds=5,
+        fallback_cloud_provider="openai"
+    )
+    mock_get_settings.return_value = settings
+
+    # Mocking Ollama and OpenAI instances
+    mock_ollama_instance = MagicMock()
+    mock_ollama.return_value = mock_ollama_instance
+
+    mock_openai_instance = MagicMock()
+    mock_openai.return_value = mock_openai_instance
+
+    # Call get_llm_client
+    client = get_llm_client()
+
+    # Check that FallbackLLMClient was instantiated with correct arguments
+    assert mock_fallback.called
+    args, kwargs = mock_fallback.call_args
+    assert args[0] == mock_ollama_instance
+    assert args[1] == mock_openai_instance
+
+    # Check that primary (Ollama) was created with correct settings (timeout=5)
+    assert mock_ollama.called
+    ollama_settings = mock_ollama.call_args.kwargs.get('settings')
+    assert ollama_settings is not None
+    assert ollama_settings.llm_timeout_seconds == 5
+    assert ollama_settings.llm_max_retries == 1


### PR DESCRIPTION
Implemented an automatic fallback mechanism from Ollama to Cloud LLM providers. When enabled, if Ollama processing takes longer than the configured threshold, the system automatically retries the request using a cloud provider (like OpenAI or Anthropic). This ensures that users with slow hardware can still complete extractions in a reasonable timeframe.

Fixes #105

---
*PR created automatically by Jules for task [6639643281559447312](https://jules.google.com/task/6639643281559447312) started by @username-anthony-is-not-available*