### PR TITLE
Implement Direct IMAP Sync

### DIFF
--- a/digital_asset_harvester/config.py
+++ b/digital_asset_harvester/config.py
@@ -58,6 +58,15 @@ class HarvesterSettings:
     include_confidence_scores: bool = False
 
     enable_imap: bool = False
+    imap_server: str = ""
+    imap_user: str = ""
+    imap_password: str = ""
+    imap_auth_type: str = "password"
+    imap_folder: str = "INBOX"
+    imap_query: str = "ALL"
+    imap_client_id: str = ""
+    imap_authority: str = ""
+
     enable_koinly_csv_export: bool = False
     enable_ctc_csv_export: bool = False
     enable_cra_csv_export: bool = False

--- a/digital_asset_harvester/utils/sync_state.py
+++ b/digital_asset_harvester/utils/sync_state.py
@@ -1,0 +1,43 @@
+import json
+import os
+from typing import Dict, Any
+
+class SyncState:
+    """Manages persistent sync state for IMAP accounts."""
+
+    def __init__(self, state_file: str = ".sync_state.json") -> None:
+        self.state_file = state_file
+        self.state: Dict[str, Any] = self._load_state()
+
+    def _load_state(self) -> Dict[str, Any]:
+        """Loads the state from the JSON file."""
+        if os.path.exists(self.state_file):
+            try:
+                with open(self.state_file, "r") as f:
+                    return json.load(f)
+            except (json.JSONDecodeError, IOError):
+                return {}
+        return {}
+
+    def _save_state(self) -> None:
+        """Saves the current state to the JSON file."""
+        try:
+            with open(self.state_file, "w") as f:
+                json.dump(self.state, f, indent=2)
+        except IOError:
+            pass
+
+    def _get_key(self, server: str, user: str, folder: str) -> str:
+        """Generates a unique key for the given account and folder."""
+        return f"{server}|{user}|{folder}"
+
+    def get_last_uid(self, server: str, user: str, folder: str) -> int:
+        """Retrieves the last processed UID for the given account and folder."""
+        key = self._get_key(server, user, folder)
+        return self.state.get(key, 0)
+
+    def set_last_uid(self, server: str, user: str, folder: str, uid: int) -> None:
+        """Sets the last processed UID for the given account and folder."""
+        key = self._get_key(server, user, folder)
+        self.state[key] = uid
+        self._save_state()

--- a/digital_asset_harvester/web/templates/index.html
+++ b/digital_asset_harvester/web/templates/index.html
@@ -7,11 +7,23 @@
 <body>
     <div class="container">
         <h1>Digital Asset Purchase Harvester</h1>
-        <p>Upload your mbox file to extract cryptocurrency purchase information.</p>
-        <form action="/api/upload" method="post" enctype="multipart/form-data" class="upload-form">
-            <input type="file" name="file">
-            <input type="submit" value="Upload and Process">
-        </form>
+        <p>Upload your mbox file or sync directly from your email inbox.</p>
+
+        <div class="card">
+            <h2>Mbox Upload</h2>
+            <form action="/api/upload" method="post" enctype="multipart/form-data" class="upload-form">
+                <input type="file" name="file">
+                <input type="submit" value="Upload and Process">
+            </form>
+        </div>
+
+        <div class="card">
+            <h2>Direct IMAP Sync</h2>
+            <p>Fetch new emails directly from your configured IMAP server.</p>
+            <form action="/api/sync/imap" method="post">
+                <input type="submit" value="Sync from IMAP">
+            </form>
+        </div>
     </div>
 </body>
 </html>

--- a/tests/utils/test_sync_state.py
+++ b/tests/utils/test_sync_state.py
@@ -1,0 +1,45 @@
+import os
+import json
+import tempfile
+import pytest
+from digital_asset_harvester.utils.sync_state import SyncState
+
+def test_sync_state_persistence():
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        state_file = tmp.name
+
+    try:
+        sync_state = SyncState(state_file=state_file)
+
+        # Initial state should be 0
+        assert sync_state.get_last_uid("imap.example.com", "user@example.com", "INBOX") == 0
+
+        # Set a UID
+        sync_state.set_last_uid("imap.example.com", "user@example.com", "INBOX", 123)
+        assert sync_state.get_last_uid("imap.example.com", "user@example.com", "INBOX") == 123
+
+        # Verify it's in the file
+        with open(state_file, "r") as f:
+            data = json.load(f)
+            assert data["imap.example.com|user@example.com|INBOX"] == 123
+
+        # Create a new instance and verify it loads the state
+        new_sync_state = SyncState(state_file=state_file)
+        assert new_sync_state.get_last_uid("imap.example.com", "user@example.com", "INBOX") == 123
+
+    finally:
+        if os.path.exists(state_file):
+            os.remove(state_file)
+
+def test_sync_state_invalid_json():
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        state_file = tmp.name
+        tmp.write(b"invalid json")
+
+    try:
+        # Should not crash and should return default state
+        sync_state = SyncState(state_file=state_file)
+        assert sync_state.get_last_uid("any", "any", "any") == 0
+    finally:
+        if os.path.exists(state_file):
+            os.remove(state_file)


### PR DESCRIPTION
Implemented "Direct IMAP" sync to allow users to fetch emails directly from their inboxes without manual mbox exports. The solution includes incremental harvesting using IMAP UIDs, a persistent sync state mechanism, and integration with both the CLI and Web UI. addressed feedback regarding combined query logic, folder support, and configuration precedence.

Fixes #102

---
*PR created automatically by Jules for task [9503089384186423355](https://jules.google.com/task/9503089384186423355) started by @username-anthony-is-not-available*