### PR TITLE
Map Extracted Assets to Standard CoinGecko IDs

### DIFF
--- a/digital_asset_harvester/exporters/cra.py
+++ b/digital_asset_harvester/exporters/cra.py
@@ -35,7 +35,7 @@ class CRAReportGenerator:
             "Sent Currency": purchase.get("currency", ""),
             "Fee Quantity": str(purchase.get("fee_amount", "")) if purchase.get("fee_amount") is not None else "",
             "Fee Currency": purchase.get("fee_currency", ""),
-            "Description": f"Transaction at {purchase.get('vendor', 'Unknown')}",
+            "Description": f"Transaction at {purchase.get('vendor', 'Unknown')}" + (f" (Asset ID: {purchase.get('asset_id')})" if purchase.get('asset_id') else ""),
         }
         return row
 
@@ -167,20 +167,22 @@ def write_purchase_data_to_cra_pdf(purchases: List[Dict[str, Any]], output_file:
 
     pdf.set_font("helvetica", size=8)
     # Header
-    pdf.cell(30, 8, "Date", border=1)
-    pdf.cell(30, 8, "Exchange", border=1)
-    pdf.cell(25, 8, "Type", border=1)
-    pdf.cell(25, 8, "Asset", border=1)
-    pdf.cell(30, 8, "Quantity", border=1)
+    pdf.cell(25, 8, "Date", border=1)
+    pdf.cell(25, 8, "Exchange", border=1)
+    pdf.cell(20, 8, "Type", border=1)
+    pdf.cell(20, 8, "Asset", border=1)
+    pdf.cell(35, 8, "Asset ID", border=1)
+    pdf.cell(25, 8, "Quantity", border=1)
     pdf.cell(30, 8, "Spent", border=1)
     pdf.ln()
 
     for p in purchase_dicts:
-        pdf.cell(30, 8, str(p.get("purchase_date") or ""), border=1)
-        pdf.cell(30, 8, str(p.get("vendor") or "Unknown"), border=1)
-        pdf.cell(25, 8, str(p.get("transaction_type") or "buy"), border=1)
-        pdf.cell(25, 8, str(p.get("item_name") or ""), border=1)
-        pdf.cell(30, 8, str(p.get("amount") or ""), border=1)
+        pdf.cell(25, 8, str(p.get("purchase_date") or ""), border=1)
+        pdf.cell(25, 8, str(p.get("vendor") or "Unknown"), border=1)
+        pdf.cell(20, 8, str(p.get("transaction_type") or "buy"), border=1)
+        pdf.cell(20, 8, str(p.get("item_name") or ""), border=1)
+        pdf.cell(35, 8, str(p.get("asset_id") or ""), border=1)
+        pdf.cell(25, 8, str(p.get("amount") or ""), border=1)
         pdf.cell(30, 8, f"{p.get('total_spent') or ''} {p.get('currency') or ''}", border=1)
         pdf.ln()
 

--- a/digital_asset_harvester/exporters/cryptotaxcalculator.py
+++ b/digital_asset_harvester/exporters/cryptotaxcalculator.py
@@ -48,7 +48,7 @@ class CryptoTaxCalculatorReportGenerator:
             "From": purchase.get("vendor", ""),
             "To": "",
             "ID": purchase.get("transaction_id", ""),
-            "Description": f"Extracted from {purchase.get('vendor', 'Unknown')}",
+            "Description": f"Extracted from {purchase.get('vendor', 'Unknown')}" + (f" (Asset ID: {purchase.get('asset_id')})" if purchase.get('asset_id') else ""),
         }
         return row
 

--- a/digital_asset_harvester/exporters/koinly.py
+++ b/digital_asset_harvester/exporters/koinly.py
@@ -36,7 +36,7 @@ class KoinlyReportGenerator:
             "Fee Currency": purchase.get("fee_currency", ""),
             "Net Worth Amount": "",
             "Net Worth Currency": "",
-            "Description": f"{tx_type.capitalize()} from {purchase.get('vendor', 'Unknown')}",
+            "Description": f"{tx_type.capitalize()} from {purchase.get('vendor', 'Unknown')}" + (f" (Asset ID: {purchase.get('asset_id')})" if purchase.get('asset_id') else ""),
             "TxHash": purchase.get("transaction_id", ""),
         }
 

--- a/digital_asset_harvester/processing/email_purchase_extractor.py
+++ b/digital_asset_harvester/processing/email_purchase_extractor.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional, Set
 from digital_asset_harvester.config import HarvesterSettings, get_settings
 from digital_asset_harvester.confidence import calculate_confidence
 from digital_asset_harvester.utils.pii_scrubber import PIIScrubber
+from digital_asset_harvester.utils.asset_mapping import mapper as asset_mapper
 from digital_asset_harvester.llm import get_llm_client
 from digital_asset_harvester.llm.ollama_client import LLMError
 from digital_asset_harvester.llm.provider import LLMProvider
@@ -484,6 +485,11 @@ class EmailPurchaseExtractor:
                         purchase_info["fee_amount"] = float(purchase_record.fee_amount)
 
                     purchase_info["transaction_type"] = purchase_record.transaction_type
+
+                    # Populate asset_id if not already present
+                    if not purchase_info.get("asset_id") and purchase_info.get("item_name"):
+                        purchase_info["asset_id"] = asset_mapper.get_asset_id(purchase_info["item_name"])
+
                     validated_purchases.append(purchase_info)
                 else:
                     logger.warning("Extracted purchase data failed validation")

--- a/digital_asset_harvester/utils/asset_mapping.py
+++ b/digital_asset_harvester/utils/asset_mapping.py
@@ -1,0 +1,106 @@
+"""Fuzzy mapping service for cryptocurrency assets to CoinGecko IDs."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, Optional, Tuple
+
+from rapidfuzz import process, fuzz
+
+logger = logging.getLogger(__name__)
+
+# Predefined list of common cryptocurrencies for mapping
+# (id, symbol, name)
+COMMON_ASSETS: List[Tuple[str, str, str]] = [
+    ("bitcoin", "btc", "Bitcoin"),
+    ("ethereum", "eth", "Ethereum"),
+    ("tether", "usdt", "Tether"),
+    ("usd-coin", "usdc", "USD Coin"),
+    ("binancecoin", "bnb", "BNB"),
+    ("ripple", "xrp", "XRP"),
+    ("cardano", "ada", "Cardano"),
+    ("solana", "sol", "Solana"),
+    ("dogecoin", "doge", "Dogecoin"),
+    ("polkadot", "dot", "Polkadot"),
+    ("polygon", "matic", "Polygon"),
+    ("litecoin", "ltc", "Litecoin"),
+    ("chainlink", "link", "Chainlink"),
+    ("bitcoin-cash", "bch", "Bitcoin Cash"),
+    ("stellar", "xlm", "Stellar"),
+    ("monero", "xmr", "Monero"),
+    ("ethereum-classic", "etc", "Ethereum Classic"),
+    ("avalanche-2", "avax", "Avalanche"),
+    ("wrapped-bitcoin", "wbtc", "Wrapped Bitcoin"),
+    ("dai", "dai", "Dai"),
+    ("uniswap", "uni", "Uniswap"),
+    ("cosmos", "atom", "Cosmos"),
+    ("shiba-inu", "shib", "Shiba Inu"),
+    ("leo-token", "leo", "LEO Token"),
+    ("tron", "trx", "TRON"),
+    ("toncoin", "ton", "Toncoin"),
+    ("near", "near", "NEAR Protocol"),
+    ("optimism", "op", "Optimism"),
+    ("arbitrum", "arb", "Arbitrum"),
+    ("pepe", "pepe", "Pepe"),
+    ("kaspa", "kas", "Kaspa"),
+    ("aptos", "apt", "Aptos"),
+    ("stacks", "stx", "Stacks"),
+    ("hedera-hashgraph", "hbar", "Hedera"),
+    ("filecoin", "fil", "Filecoin"),
+    ("vechain", "vet", "VeChain"),
+    ("maker", "mkr", "Maker"),
+    ("lido-dao", "ldo", "Lido DAO"),
+    ("render-token", "rndr", "Render"),
+    ("thorchain", "rune", "THORChain"),
+]
+
+
+class CoinGeckoMapper:
+    """Service for mapping asset names or symbols to CoinGecko IDs."""
+
+    def __init__(self, assets: Optional[List[Tuple[str, str, str]]] = None):
+        self.assets = assets or COMMON_ASSETS
+        # Build lookup tables for exact matches
+        self.symbol_to_id = {symbol.lower(): cid for cid, symbol, name in self.assets}
+        self.name_to_id = {name.lower(): cid for cid, symbol, name in self.assets}
+
+        # Build list of strings for fuzzy matching (symbols and names)
+        self.fuzzy_choices = []
+        for cid, symbol, name in self.assets:
+            self.fuzzy_choices.append(symbol.lower())
+            self.fuzzy_choices.append(name.lower())
+
+    def get_asset_id(self, item_name: str, threshold: int = 80) -> Optional[str]:
+        """
+        Map an item name (symbol or full name) to a CoinGecko ID.
+
+        Uses exact matching first, then fuzzy matching.
+        """
+        if not item_name:
+            return None
+
+        clean_name = item_name.strip().lower()
+
+        # 1. Try exact symbol match
+        if clean_name in self.symbol_to_id:
+            return self.symbol_to_id[clean_name]
+
+        # 2. Try exact name match
+        if clean_name in self.name_to_id:
+            return self.name_to_id[clean_name]
+
+        # 3. Try fuzzy matching
+        match = process.extractOne(clean_name, self.fuzzy_choices, scorer=fuzz.WRatio)
+        if match and match[1] >= threshold:
+            best_string = match[0]
+            # Find the ID for this string
+            if best_string in self.symbol_to_id:
+                return self.symbol_to_id[best_string]
+            if best_string in self.name_to_id:
+                return self.name_to_id[best_string]
+
+        logger.debug("Could not map asset name '%s' to a CoinGecko ID", item_name)
+        return None
+
+# Singleton instance
+mapper = CoinGeckoMapper()

--- a/digital_asset_harvester/utils/data_utils.py
+++ b/digital_asset_harvester/utils/data_utils.py
@@ -39,6 +39,9 @@ def normalize_for_frontend(purchase: Dict[str, Any]) -> Dict[str, Any]:
     if "fee_currency" not in normalized:
         normalized["fee_currency"] = ""
 
+    if "asset_id" not in normalized:
+        normalized["asset_id"] = None
+
     return normalized
 
 
@@ -68,5 +71,10 @@ def denormalize_from_frontend(purchase: Dict[str, Any]) -> Dict[str, Any]:
     # Restore confidence
     if "confidence_score" in denormalized:
         denormalized["confidence"] = denormalized["confidence_score"]
+
+    # Ensure asset_id is preserved
+    if "asset_id" in denormalized:
+        # already has the right key
+        pass
 
     return denormalized

--- a/digital_asset_harvester/validation/schemas.py
+++ b/digital_asset_harvester/validation/schemas.py
@@ -22,6 +22,7 @@ class PurchaseRecord:
     extraction_notes: Optional[str] = None
     confidence: Optional[float] = None
     extraction_method: Optional[str] = None
+    asset_id: Optional[str] = None
 
     @classmethod
     def from_raw(cls, data):
@@ -65,4 +66,5 @@ class PurchaseRecord:
             extraction_notes=str(data.get("extraction_notes", "")) or None,
             confidence=confidence,
             extraction_method=data.get("extraction_method"),
+            asset_id=str(data.get("asset_id", "")) or None,
         )

--- a/digital_asset_harvester/web/templates/status.html
+++ b/digital_asset_harvester/web/templates/status.html
@@ -121,6 +121,7 @@
             row.querySelector('.edit-ca').value = row.querySelector('.view-ca').textContent;
             row.querySelector('.edit-fa').value = row.querySelector('.view-fa').textContent;
             row.querySelector('.edit-fc').value = row.querySelector('.view-fc').textContent;
+            row.querySelector('.edit-aid').value = row.querySelector('.view-aid').textContent;
         }
 
         async function saveRow(index, taskId) {
@@ -134,7 +135,8 @@
                 crypto_currency: row.querySelector('.edit-cc').value,
                 crypto_amount: row.querySelector('.edit-ca').value,
                 fee_amount: row.querySelector('.edit-fa').value,
-                fee_currency: row.querySelector('.edit-fc').value
+                fee_currency: row.querySelector('.edit-fc').value,
+                asset_id: row.querySelector('.edit-aid').value
             };
 
             const response = await fetch(`/api/task/${taskId}/records/${index}`, {
@@ -217,6 +219,7 @@
             row.querySelector('.view-ca').textContent = record.crypto_amount || '';
             row.querySelector('.view-fa').textContent = record.fee_amount || '';
             row.querySelector('.view-fc').textContent = record.fee_currency || '';
+            row.querySelector('.view-aid').textContent = record.asset_id || '';
             row.querySelector('.view-status').textContent = record.review_status || 'pending';
 
             const approveBtn = row.querySelector('.approve-btn');
@@ -304,10 +307,11 @@
                         <th onclick="sortTable(6)">Crypto Currency</th>
                         <th onclick="sortTable(7)">Fee Amount</th>
                         <th onclick="sortTable(8)">Fee Currency</th>
-                        <th onclick="sortTable(9)">Date</th>
-                        <th onclick="sortTable(10)">Transaction ID</th>
-                        <th onclick="sortTable(11)">Confidence</th>
-                        <th onclick="sortTable(12)">Status</th>
+                        <th onclick="sortTable(9)">Asset ID</th>
+                        <th onclick="sortTable(10)">Date</th>
+                        <th onclick="sortTable(11)">Transaction ID</th>
+                        <th onclick="sortTable(12)">Confidence</th>
+                        <th onclick="sortTable(13)">Status</th>
                         <th>Actions</th>
                     </tr>
                 </thead>
@@ -403,6 +407,10 @@
                     <td>
                         <span class="view-mode view-fc">${purchase.fee_currency || ''}</span>
                         <input type="text" class="edit-mode edit-fc editable-input" value="${purchase.fee_currency || ''}" style="display:none">
+                    </td>
+                    <td>
+                        <span class="view-mode view-aid">${purchase.asset_id || ''}</span>
+                        <input type="text" class="edit-mode edit-aid editable-input" value="${purchase.asset_id || ''}" style="display:none">
                     </td>
                     <td>
                         <span class="view-mode view-date">${purchase.purchase_date || ''}</span>

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ jinja2
 openai
 anthropic
 fpdf2>=2.8.0
+rapidfuzz


### PR DESCRIPTION
This change implements a fuzzy mapping service that converts extracted asset names (like 'BTC' or 'Bitcoin') to standard CoinGecko IDs (like 'bitcoin'). This helps avoid ticker collisions for global investors and improves the quality of tax reports. The mapping is available in the Web UI for manual review and included in all export formats (CSV and PDF).

Fixes #139

---
*PR created automatically by Jules for task [16448066139759216226](https://jules.google.com/task/16448066139759216226) started by @username-anthony-is-not-available*