### PR TITLE
Parallelize Email Parsing across CPU Cores

### DIFF
--- a/digital_asset_harvester/config.py
+++ b/digital_asset_harvester/config.py
@@ -48,6 +48,7 @@ class HarvesterSettings:
 
     batch_size: int = 10
     enable_parallel_processing: bool = False
+    enable_multiprocessing: bool = False
     max_workers: int = 5
 
     strict_validation: bool = True

--- a/digital_asset_harvester/ingest/mbox_reader.py
+++ b/digital_asset_harvester/ingest/mbox_reader.py
@@ -9,11 +9,14 @@ class MboxDataExtractor:
     def __init__(self, mbox_file: str):
         self.mbox_file = mbox_file
 
-    def extract_emails(self) -> Generator[Dict[str, Any], None, None]:
+    def extract_emails(self, raw: bool = False) -> Generator[Any, None, None]:
         try:
             mbox = mailbox.mbox(self.mbox_file)
         except (FileNotFoundError, mailbox.Error):
             return
 
         for message in mbox:
-            yield message_to_dict(message)
+            if raw:
+                yield message.as_string()
+            else:
+                yield message_to_dict(message)

--- a/digital_asset_harvester/llm/__init__.py
+++ b/digital_asset_harvester/llm/__init__.py
@@ -14,7 +14,9 @@ if TYPE_CHECKING:
     from .provider import LLMProvider
 
 
-def get_llm_client(provider: str | None = None) -> LLMProvider:
+def get_llm_client(
+    provider: str | None = None, settings: HarvesterSettings | None = None
+) -> LLMProvider:
     """Get the configured LLM client.
 
     This factory function is the single point of entry for creating LLM clients.
@@ -24,11 +26,13 @@ def get_llm_client(provider: str | None = None) -> LLMProvider:
     Args:
         provider: The name of the LLM provider to use. If not specified,
             the value from the application settings will be used.
+        settings: Optional settings object to use. If not specified, the
+            global settings will be used.
 
     Returns:
         An instance of the configured LLM provider client.
     """
-    settings = get_settings()
+    settings = settings or get_settings()
     provider_name = (provider or settings.llm_provider).lower()
 
     if not settings.enable_cloud_llm and provider_name != "ollama":
@@ -52,7 +56,9 @@ def get_llm_client(provider: str | None = None) -> LLMProvider:
             primary = OllamaLLMClient(settings=primary_settings)
 
             # Secondary client using configured fallback provider
-            secondary = get_llm_client(provider=settings.fallback_cloud_provider)
+            secondary = get_llm_client(
+                provider=settings.fallback_cloud_provider, settings=settings
+            )
             return FallbackLLMClient(primary, secondary)
 
         return OllamaLLMClient(settings=settings)

--- a/tests/test_cli_v2.py
+++ b/tests/test_cli_v2.py
@@ -84,7 +84,7 @@ def test_run_mbox_calls_dependencies(mocker):
 
     # THEN
     assert result == 0
-    m_get_settings.assert_called_once()
+    m_get_settings.assert_called()
     m_configure_logging.assert_called_once()
     m_mbox_extractor.assert_called_once_with("test.mbox")
     m_llm_client.assert_called_once()
@@ -195,10 +195,12 @@ def test_run_gmail_calls_dependencies(mocker):
 
     # THEN
     assert result == 0
-    m_get_settings.assert_called_once()
+    m_get_settings.assert_called()
     m_configure_logging.assert_called_once()
     m_gmail_client.assert_called_once()
-    m_gmail_client.return_value.search_emails.assert_called_once_with("test query")
+    m_gmail_client.return_value.search_emails.assert_called_once_with(
+        "test query", raw=m_get_settings.return_value.enable_multiprocessing
+    )
     m_llm_client.assert_called_once()
     m_extractor.assert_called_once()
     m_process_emails.assert_called_once()

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -1,0 +1,33 @@
+import pytest
+from digital_asset_harvester.cli import process_emails, HarvesterSettings
+from digital_asset_harvester.processing.email_purchase_extractor import EmailPurchaseExtractor
+from digital_asset_harvester.telemetry import StructuredLoggerFactory
+from unittest.mock import MagicMock
+
+def test_process_emails_uses_multiprocessing(mocker):
+    # GIVEN
+    settings = HarvesterSettings(
+        enable_multiprocessing=True,
+        max_workers=3
+    )
+    mock_extractor = MagicMock()
+    mock_extractor.settings = settings
+    factory = StructuredLoggerFactory(json_output=False)
+
+    emails = ["raw email 1", "raw email 2"]
+
+    m_executor = mocker.patch("concurrent.futures.ProcessPoolExecutor")
+    m_as_completed = mocker.patch("concurrent.futures.as_completed", return_value=[])
+
+    # WHEN
+    process_emails(emails, mock_extractor, factory, show_progress=False)
+
+    # THEN
+    m_executor.assert_called_once_with(max_workers=3)
+
+def test_cli_multiprocessing_flag():
+    from digital_asset_harvester.cli import build_parser
+    settings = HarvesterSettings()
+    parser = build_parser(settings)
+    args = parser.parse_args(["--mbox-file", "test.mbox", "--multiprocessing"])
+    assert args.multiprocessing is True


### PR DESCRIPTION
This change implements multiprocessing for the Digital Asset Purchase Harvester, addressing the need for high-performance processing of large email datasets (10,000+ emails). 

While the previous implementation used threading, which is suitable for I/O-bound cloud LLM calls, it was limited by the Global Interpreter Lock (GIL) for CPU-bound tasks like raw email parsing (HTML stripping, PII scrubbing) and local LLM execution via Ollama.

Key improvements:
1. **Multiprocessing Support**: Introduced `ProcessPoolExecutor` in the processing pipeline, enabled via the new `--multiprocessing` flag.
2. **Parallel Parsing**: Updated all ingestion sources (mbox, IMAP, Gmail) to allow yielding raw email content. This enables worker processes to perform the heavy lifting of parsing and cleaning the email content in parallel.
3. **Worker Robustness**: Modified the LLM client factory and the processing worker to correctly initialize and configure components within subprocesses, avoiding pickling issues.
4. **Maintained Threading Option**: Power users can still choose between threading (via `--parallel`) and multiprocessing (via `--multiprocessing`) based on their specific hardware and LLM provider.

Performance verified with benchmarks and existing test suites pass.

Fixes #138

---
*PR created automatically by Jules for task [4640659622246786582](https://jules.google.com/task/4640659622246786582) started by @username-anthony-is-not-available*