### PR TITLE
[Security] Local LLM (Ollama) Privacy Hardening

### DIFF
--- a/digital_asset_harvester/config.py
+++ b/digital_asset_harvester/config.py
@@ -23,7 +23,9 @@ class HarvesterSettings:
     llm_model_name: str = "llama3.2:3b"
     llm_max_retries: int = 3
     llm_timeout_seconds: int = 30
+    ollama_base_url: str = "http://localhost:11434"
 
+    enable_privacy_mode: bool = False
     enable_cloud_llm: bool = False
     llm_provider: str = "ollama"
     enable_ollama_fallback: bool = False

--- a/digital_asset_harvester/llm/__init__.py
+++ b/digital_asset_harvester/llm/__init__.py
@@ -35,6 +35,17 @@ def get_llm_client(
     settings = settings or get_settings()
     provider_name = (provider or settings.llm_provider).lower()
 
+    if settings.enable_privacy_mode:
+        if provider_name != "ollama":
+            raise ValueError(
+                f"Privacy mode is enabled. LLM provider '{provider_name}' is not allowed. "
+                "Only local Ollama is permitted in privacy mode."
+            )
+        if settings.enable_ollama_fallback:
+            raise ValueError(
+                "Privacy mode is enabled. Ollama fallback to cloud LLM is not allowed."
+            )
+
     if not settings.enable_cloud_llm and provider_name != "ollama":
         raise ValueError(
             "Cloud LLM providers are not enabled. "

--- a/digital_asset_harvester/llm/ollama_client.py
+++ b/digital_asset_harvester/llm/ollama_client.py
@@ -37,7 +37,10 @@ class OllamaLLMClient(LLMProvider):
     ) -> None:
         self.settings = settings or get_settings()
         timeout = float(self.settings.llm_timeout_seconds)
-        self._client = client or Client(timeout=timeout)
+        self._client = client or Client(
+            host=self.settings.ollama_base_url,
+            timeout=timeout,
+        )
         self.default_retries = default_retries or self.settings.llm_max_retries
 
     def generate_json(

--- a/digital_asset_harvester/processing/email_purchase_extractor.py
+++ b/digital_asset_harvester/processing/email_purchase_extractor.py
@@ -149,8 +149,8 @@ class EmailPurchaseExtractor:
         return has_purchase_keywords and not has_non_purchase_patterns
 
     def _scrub_pii_if_enabled(self, email_content: str) -> str:
-        """Apply PII scrubbing to email content if enabled in settings."""
-        if self.settings.enable_pii_scrubbing:
+        """Apply PII scrubbing to email content if enabled in settings or privacy mode."""
+        if self.settings.enable_pii_scrubbing or self.settings.enable_privacy_mode:
             logger.debug("PII scrubbing enabled, processing email content")
             return self.pii_scrubber.scrub(email_content)
         return email_content

--- a/tests/llm/test_privacy_hardening.py
+++ b/tests/llm/test_privacy_hardening.py
@@ -1,0 +1,98 @@
+"""Tests for privacy hardening features."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from digital_asset_harvester.config import HarvesterSettings
+from digital_asset_harvester.llm import get_llm_client
+from digital_asset_harvester.processing.email_purchase_extractor import EmailPurchaseExtractor
+
+
+def test_privacy_mode_restricts_cloud_providers():
+    """Verify that privacy mode prevents using cloud providers."""
+    settings = HarvesterSettings(
+        enable_privacy_mode=True,
+        enable_cloud_llm=True,
+        llm_provider="openai"
+    )
+
+    with pytest.raises(ValueError, match="Privacy mode is enabled. LLM provider 'openai' is not allowed"):
+        get_llm_client(settings=settings)
+
+
+def test_privacy_mode_restricts_ollama_fallback():
+    """Verify that privacy mode prevents Ollama fallback to cloud."""
+    settings = HarvesterSettings(
+        enable_privacy_mode=True,
+        enable_ollama_fallback=True,
+        llm_provider="ollama"
+    )
+
+    with pytest.raises(ValueError, match="Privacy mode is enabled. Ollama fallback to cloud LLM is not allowed"):
+        get_llm_client(settings=settings)
+
+
+@patch("digital_asset_harvester.llm.ollama_client.Client")
+def test_ollama_client_uses_configured_base_url(mock_client_class):
+    """Verify that OllamaLLMClient uses the configured base URL."""
+    custom_url = "http://secure-ollama:11434"
+    settings = HarvesterSettings(
+        ollama_base_url=custom_url,
+        llm_provider="ollama"
+    )
+
+    get_llm_client(settings=settings)
+
+    # Check that Client was initialized with the custom host
+    mock_client_class.assert_called_once()
+    args, kwargs = mock_client_class.call_args
+    assert kwargs["host"] == custom_url
+
+
+def test_privacy_mode_enables_pii_scrubbing():
+    """Verify that privacy mode automatically enables PII scrubbing in the extractor."""
+    settings = HarvesterSettings(
+        enable_privacy_mode=True,
+        enable_pii_scrubbing=False,  # Explicitly disabled
+        llm_provider="ollama"
+    )
+
+    # Mock LLM client to avoid initialization issues
+    mock_llm = MagicMock()
+    extractor = EmailPurchaseExtractor(settings=settings, llm_client=mock_llm)
+
+    email_content = "From: alice@example.com\nSubject: Buy BTC\n\nHi Alice, you bought 1 BTC."
+
+    with patch.object(extractor.pii_scrubber, "scrub", return_value="SCRUBBED") as mock_scrub:
+        extractor._scrub_pii_if_enabled(email_content)
+        mock_scrub.assert_called_once_with(email_content)
+
+
+def test_no_privacy_mode_respects_pii_settings():
+    """Verify that when privacy mode is off, PII scrubbing respects the setting."""
+    # Case 1: Privacy mode OFF, PII scrubbing OFF
+    settings_off = HarvesterSettings(
+        enable_privacy_mode=False,
+        enable_pii_scrubbing=False,
+        llm_provider="ollama"
+    )
+    mock_llm = MagicMock()
+    extractor_off = EmailPurchaseExtractor(settings=settings_off, llm_client=mock_llm)
+
+    with patch.object(extractor_off.pii_scrubber, "scrub") as mock_scrub:
+        result = extractor_off._scrub_pii_if_enabled("content")
+        mock_scrub.assert_not_called()
+        assert result == "content"
+
+    # Case 2: Privacy mode OFF, PII scrubbing ON
+    settings_on = HarvesterSettings(
+        enable_privacy_mode=False,
+        enable_pii_scrubbing=True,
+        llm_provider="ollama"
+    )
+    extractor_on = EmailPurchaseExtractor(settings=settings_on, llm_client=mock_llm)
+
+    with patch.object(extractor_on.pii_scrubber, "scrub", return_value="SCRUBBED") as mock_scrub:
+        result = extractor_on._scrub_pii_if_enabled("content")
+        mock_scrub.assert_called_once_with("content")
+        assert result == "SCRUBBED"


### PR DESCRIPTION
This change implements a "Privacy Mode" for the Digital Asset Purchase Harvester, ensuring that email data remains local when using Ollama. 

Key changes:
1.  **Privacy Mode Guardrails**: Introduced `enable_privacy_mode` in configuration. When enabled, the application strictly prevents data from being sent to cloud LLM providers and disables automatic fallbacks.
2.  **Configurable Local LLM**: Added `ollama_base_url` to allow users to specify their local Ollama instance explicitly.
3.  **Automatic Data Protection**: Privacy mode now automatically triggers PII scrubbing during extraction, providing an extra layer of defense even for local processing.
4.  **Verification**: Added a new test suite `tests/llm/test_privacy_hardening.py` to verify all privacy constraints and behavior.

Fixes #135

---
*PR created automatically by Jules for task [9683796184058488845](https://jules.google.com/task/9683796184058488845) started by @username-anthony-is-not-available*