### PR TITLE
Add Confidence Scoring to LLM Extraction Pipeline

### DIFF
--- a/digital_asset_harvester/confidence.py
+++ b/digital_asset_harvester/confidence.py
@@ -17,9 +17,15 @@ def calculate_confidence(purchase: PurchaseRecord) -> float:
     """
     Calculate the confidence of an extraction based on the method used.
 
-    Note: Currently, only LLM extraction is implemented. REGEX and HEURISTIC
-    are placeholders for future extraction methods.
+    If the purchase record already has a confidence score (e.g., from an LLM),
+    that score is prioritized. Otherwise, a default score is returned based
+    on the extraction method.
     """
+    # Prioritize existing confidence if available
+    if purchase.confidence is not None:
+        return purchase.confidence
+
+    # Fallback to defaults based on method
     if purchase.extraction_method == ExtractionMethod.REGEX.value:
         return 0.95
     elif purchase.extraction_method == ExtractionMethod.HEURISTIC.value:

--- a/digital_asset_harvester/prompts/manager.py
+++ b/digital_asset_harvester/prompts/manager.py
@@ -62,6 +62,12 @@ Return a JSON object with this exact structure:
     "confidence": float (0.0 to 1.0),
     "reasoning": "Brief explanation of your decision"
 }
+
+CONFIDENCE BENCHMARKS:
+- 1.0: Clearly an automated purchase confirmation or trade receipt.
+- 0.8-0.9: Likely a purchase but wording is slightly non-standard.
+- 0.5-0.7: Ambiguous email that might be transactional but lacks clear "buy/purchased" confirmation.
+- <0.5: Unlikely to be a purchase (marketing, newsletter, etc).
 """,
 )
 
@@ -129,6 +135,12 @@ Return JSON with this exact structure:
         }
     ]
 }
+
+CONFIDENCE BENCHMARKS:
+- 1.0: All core fields (date, asset, amount, vendor) are explicitly and unambiguously present.
+- 0.8-0.9: Core info is clear, but minor fields (like currency or fees) might be inferred from context.
+- 0.5-0.7: Some core information is ambiguous or requires significant interpretation.
+- <0.5: High uncertainty; key information like amount or asset is unclear.
 
 If no valid purchase information can be extracted, return an empty array for the "transactions" field.
 """,


### PR DESCRIPTION
This change adds support for dynamic confidence scoring in the LLM extraction pipeline. 

1. **Prompt Updates**: The `extraction` and `classification` prompts in `digital_asset_harvester/prompts/manager.py` now include explicit "CONFIDENCE BENCHMARKS". These instructions guide the LLM to provide consistent scoring based on the clarity of the evidence in the email.
2. **Logic Updates**: The `calculate_confidence` function in `digital_asset_harvester/confidence.py` was updated to check if a `confidence` score is already present on the `PurchaseRecord` (e.g., extracted from the LLM response). If present, it uses that score; otherwise, it falls back to the existing method-based defaults.
3. **Verification**: A reproduction test confirmed that the LLM-provided score is no longer overwritten by the 0.7 default. The full test suite was run to ensure no regressions.

Fixes #133

---
*PR created automatically by Jules for task [16892685076643944886](https://jules.google.com/task/16892685076643944886) started by @username-anthony-is-not-available*