### PR TITLE
Add Golden mbox integration test suite

### DIFF
--- a/tests/fixtures/golden.mbox
+++ b/tests/fixtures/golden.mbox
@@ -1,0 +1,114 @@
+From MAILER-DAEMON Sun Feb 15 17:30:04 2026
+From: Coinbase <no-reply@coinbase.com>
+Subject: Your Coinbase purchase of 0.001 BTC
+Date: Mon, 1 Jan 2024 10:00:00 +0000
+Message-ID: <coinbase_purchase@golden-test.local>
+
+You successfully purchased 0.001 BTC for $100.00 USD.
+
+From MAILER-DAEMON Sun Feb 15 17:30:04 2026
+From: Binance <do-not-reply@binance.com>
+Subject: Your order to buy 0.1 ETH has been filled
+Date: Tue, 2 Jan 2024 11:00:00 +0000
+Message-ID: <binance_purchase@golden-test.local>
+
+Your order to buy 0.1 ETH for 200.00 USD has been filled.
+
+From MAILER-DAEMON Sun Feb 15 17:30:04 2026
+From: Kraken <noreply@kraken.com>
+Subject: Trade Confirmation: Buy 0.5 XMR
+Date: Wed, 3 Jan 2024 12:00:00 +0000
+Message-ID: <kraken_purchase@golden-test.local>
+
+You have successfully bought 0.5 XMR for 50.00 EUR.
+
+From MAILER-DAEMON Sun Feb 15 17:30:04 2026
+From: Gemini <orders@gemini.com>
+Subject: Order Confirmation - Buy BTC
+Date: Thu, 4 Jan 2024 13:00:00 +0000
+Message-ID: <gemini_purchase@golden-test.local>
+
+Your order to purchase 0.005 BTC for $150.00 has been completed.
+Transaction ID: GEM-2024-001
+
+From MAILER-DAEMON Sun Feb 15 17:30:04 2026
+From: "Crypto Exchange" <noreply@crypto.com>
+Subject: Your order #12345 has been executed
+Date: Fri, 5 Jan 2024 14:00:00 +0000
+Message-ID: <cryptocom_purchase@golden-test.local>
+
+Your market order #12345 to buy 2.5 SOL has been filled at a price of $25.00 per SOL.
+Total cost: $62.50 USD.
+
+From MAILER-DAEMON Sun Feb 15 17:30:04 2026
+From: FTX <noreply@ftx.com>
+Subject: Trade Executed: BUY 10 MATIC
+Date: Sat, 6 Jan 2024 15:00:00 +0000
+Message-ID: <ftx_purchase@golden-test.local>
+
+Amount: 10 MATIC
+Price per unit: $0.85
+Total: $8.50 USD
+
+From MAILER-DAEMON Sun Feb 15 17:30:04 2026
+From: CoinSpot <support@coinspot.com.au>
+Subject: Purchase Confirmation
+Date: Sun, 7 Jan 2024 16:00:00 +0000
+Message-ID: <coinspot_purchase@golden-test.local>
+
+You have successfully purchased 50 ADA for $25.00 AUD.
+Reference: CS-20240115-001
+
+From MAILER-DAEMON Sun Feb 15 17:30:04 2026
+From: Coinbase <no-reply@coinbase.com>
+Subject: You've earned a staking reward
+Date: Mon, 8 Jan 2024 17:00:00 +0000
+Message-ID: <coinbase_staking@golden-test.local>
+
+You just earned 0.00001234 ETH in staking rewards!
+Transaction ID: CB-STAKE-2025-ABC
+
+From MAILER-DAEMON Sun Feb 15 17:30:04 2026
+From: Binance <do-not-reply@binance.com>
+Subject: Trade Confirmation
+Date: Tue, 9 Jan 2024 18:00:00 +0000
+Message-ID: <binance_multi@golden-test.local>
+
+Your trade order has been filled.
+
+Order Details:
+- Pair: BTC/USDT
+- Side: Buy
+- Amount: 0.002 BTC
+- Price: 65,000.00 USDT
+- Total: 130.00 USDT
+
+- Pair: ETH/USDT
+- Side: Buy
+- Amount: 0.1 ETH
+- Price: 3,500.00 USDT
+- Total: 350.00 USDT
+
+From MAILER-DAEMON Sun Feb 15 17:30:04 2026
+From: info@someexchange.io
+Subject: Receipt for your order
+Date: Wed, 10 Jan 2024 19:00:00 +0000
+Message-ID: <generic_llm_purchase@golden-test.local>
+
+You bought 1000 DOGE for 0.1 ETH on our platform.
+
+From MAILER-DAEMON Sun Feb 15 17:30:04 2026
+From: Newsletter <news@crypto.com>
+Subject: Crypto Weekly
+Date: Thu, 11 Jan 2024 20:00:00 +0000
+Message-ID: <newsletter@golden-test.local>
+
+Market is bullish today. Bitcoin is up 5%.
+
+From MAILER-DAEMON Sun Feb 15 17:30:04 2026
+From: Security <security@binance.com>
+Subject: New login from unknown device
+Date: Fri, 12 Jan 2024 21:00:00 +0000
+Message-ID: <security_alert@golden-test.local>
+
+We detected a login from a new device in London.

--- a/tests/fixtures/golden_expected.json
+++ b/tests/fixtures/golden_expected.json
@@ -1,0 +1,115 @@
+{
+    "coinbase_purchase": [
+        {
+            "amount": 0.001,
+            "item_name": "BTC",
+            "total_spent": 100.0,
+            "currency": "USD",
+            "vendor": "Coinbase",
+            "extraction_method": "regex"
+        }
+    ],
+    "binance_purchase": [
+        {
+            "amount": 0.1,
+            "item_name": "ETH",
+            "total_spent": 200.0,
+            "currency": "USD",
+            "vendor": "Binance",
+            "extraction_method": "regex"
+        }
+    ],
+    "kraken_purchase": [
+        {
+            "amount": 0.5,
+            "item_name": "XMR",
+            "total_spent": 50.0,
+            "currency": "EUR",
+            "vendor": "Kraken",
+            "extraction_method": "regex"
+        }
+    ],
+    "gemini_purchase": [
+        {
+            "amount": 0.005,
+            "item_name": "BTC",
+            "total_spent": 150.0,
+            "currency": "USD",
+            "vendor": "Gemini",
+            "transaction_id": "GEM-2024-001",
+            "extraction_method": "regex"
+        }
+    ],
+    "cryptocom_purchase": [
+        {
+            "amount": 2.5,
+            "item_name": "SOL",
+            "total_spent": 62.5,
+            "currency": "USD",
+            "vendor": "Crypto.com",
+            "transaction_id": "12345",
+            "extraction_method": "regex"
+        }
+    ],
+    "ftx_purchase": [
+        {
+            "amount": 10.0,
+            "item_name": "MATIC",
+            "total_spent": 8.5,
+            "currency": "USD",
+            "vendor": "FTX",
+            "extraction_method": "regex"
+        }
+    ],
+    "coinspot_purchase": [
+        {
+            "amount": 50.0,
+            "item_name": "ADA",
+            "total_spent": 25.0,
+            "currency": "AUD",
+            "vendor": "CoinSpot",
+            "transaction_id": "CS-20240115-001",
+            "extraction_method": "regex"
+        }
+    ],
+    "coinbase_staking": [
+        {
+            "amount": 1.234e-05,
+            "item_name": "ETH",
+            "vendor": "Coinbase",
+            "transaction_id": "CB-STAKE-2025-ABC",
+            "transaction_type": "staking_reward",
+            "extraction_method": "regex"
+        }
+    ],
+    "binance_multi": [
+        {
+            "amount": 0.002,
+            "item_name": "BTC",
+            "total_spent": 130.0,
+            "currency": "USDT",
+            "vendor": "Binance",
+            "extraction_method": "regex"
+        },
+        {
+            "amount": 0.1,
+            "item_name": "ETH",
+            "total_spent": 350.0,
+            "currency": "USDT",
+            "vendor": "Binance",
+            "extraction_method": "regex"
+        }
+    ],
+    "generic_llm_purchase": [
+        {
+            "amount": 1000.0,
+            "item_name": "DOGE",
+            "total_spent": 0.1,
+            "currency": "ETH",
+            "vendor": "SomeExchange",
+            "extraction_method": "llm"
+        }
+    ],
+    "newsletter": [],
+    "security_alert": []
+}

--- a/tests/integration/generate_golden_mbox.py
+++ b/tests/integration/generate_golden_mbox.py
@@ -1,0 +1,241 @@
+import json
+import mailbox
+import os
+from datetime import datetime, timezone
+
+def create_golden_mbox():
+    mbox_path = "tests/fixtures/golden.mbox"
+    expected_path = "tests/fixtures/golden_expected.json"
+
+    # Ensure fixtures directory exists
+    os.makedirs("tests/fixtures", exist_ok=True)
+
+    emails = [
+        {
+            "id": "coinbase_purchase",
+            "from": "Coinbase <no-reply@coinbase.com>",
+            "subject": "Your Coinbase purchase of 0.001 BTC",
+            "body": "You successfully purchased 0.001 BTC for $100.00 USD.",
+            "date": "Mon, 1 Jan 2024 10:00:00 +0000",
+            "expected": [
+                {
+                    "amount": 0.001,
+                    "item_name": "BTC",
+                    "total_spent": 100.0,
+                    "currency": "USD",
+                    "vendor": "Coinbase",
+                    "extraction_method": "regex"
+                }
+            ]
+        },
+        {
+            "id": "binance_purchase",
+            "from": "Binance <do-not-reply@binance.com>",
+            "subject": "Your order to buy 0.1 ETH has been filled",
+            "body": "Your order to buy 0.1 ETH for 200.00 USD has been filled.",
+            "date": "Tue, 2 Jan 2024 11:00:00 +0000",
+            "expected": [
+                {
+                    "amount": 0.1,
+                    "item_name": "ETH",
+                    "total_spent": 200.0,
+                    "currency": "USD",
+                    "vendor": "Binance",
+                    "extraction_method": "regex"
+                }
+            ]
+        },
+        {
+            "id": "kraken_purchase",
+            "from": "Kraken <noreply@kraken.com>",
+            "subject": "Trade Confirmation: Buy 0.5 XMR",
+            "body": "You have successfully bought 0.5 XMR for 50.00 EUR.",
+            "date": "Wed, 3 Jan 2024 12:00:00 +0000",
+            "expected": [
+                {
+                    "amount": 0.5,
+                    "item_name": "XMR",
+                    "total_spent": 50.0,
+                    "currency": "EUR",
+                    "vendor": "Kraken",
+                    "extraction_method": "regex"
+                }
+            ]
+        },
+        {
+            "id": "gemini_purchase",
+            "from": "Gemini <orders@gemini.com>",
+            "subject": "Order Confirmation - Buy BTC",
+            "body": "Your order to purchase 0.005 BTC for $150.00 has been completed.\nTransaction ID: GEM-2024-001",
+            "date": "Thu, 4 Jan 2024 13:00:00 +0000",
+            "expected": [
+                {
+                    "amount": 0.005,
+                    "item_name": "BTC",
+                    "total_spent": 150.0,
+                    "currency": "USD",
+                    "vendor": "Gemini",
+                    "transaction_id": "GEM-2024-001",
+                    "extraction_method": "regex"
+                }
+            ]
+        },
+        {
+            "id": "cryptocom_purchase",
+            "from": "\"Crypto Exchange\" <noreply@crypto.com>",
+            "subject": "Your order #12345 has been executed",
+            "body": "Your market order #12345 to buy 2.5 SOL has been filled at a price of $25.00 per SOL.\nTotal cost: $62.50 USD.",
+            "date": "Fri, 5 Jan 2024 14:00:00 +0000",
+            "expected": [
+                {
+                    "amount": 2.5,
+                    "item_name": "SOL",
+                    "total_spent": 62.5,
+                    "currency": "USD",
+                    "vendor": "Crypto.com",
+                    "transaction_id": "12345",
+                    "extraction_method": "regex"
+                }
+            ]
+        },
+        {
+            "id": "ftx_purchase",
+            "from": "FTX <noreply@ftx.com>",
+            "subject": "Trade Executed: BUY 10 MATIC",
+            "body": "Amount: 10 MATIC\nPrice per unit: $0.85\nTotal: $8.50 USD",
+            "date": "Sat, 6 Jan 2024 15:00:00 +0000",
+            "expected": [
+                {
+                    "amount": 10.0,
+                    "item_name": "MATIC",
+                    "total_spent": 8.5,
+                    "currency": "USD",
+                    "vendor": "FTX",
+                    "extraction_method": "regex"
+                }
+            ]
+        },
+        {
+            "id": "coinspot_purchase",
+            "from": "CoinSpot <support@coinspot.com.au>",
+            "subject": "Purchase Confirmation",
+            "body": "You have successfully purchased 50 ADA for $25.00 AUD.\nReference: CS-20240115-001",
+            "date": "Sun, 7 Jan 2024 16:00:00 +0000",
+            "expected": [
+                {
+                    "amount": 50.0,
+                    "item_name": "ADA",
+                    "total_spent": 25.0,
+                    "currency": "AUD",
+                    "vendor": "CoinSpot",
+                    "transaction_id": "CS-20240115-001",
+                    "extraction_method": "regex"
+                }
+            ]
+        },
+        {
+            "id": "coinbase_staking",
+            "from": "Coinbase <no-reply@coinbase.com>",
+            "subject": "You've earned a staking reward",
+            "body": "You just earned 0.00001234 ETH in staking rewards!\nTransaction ID: CB-STAKE-2025-ABC",
+            "date": "Mon, 8 Jan 2024 17:00:00 +0000",
+            "expected": [
+                {
+                    "amount": 0.00001234,
+                    "item_name": "ETH",
+                    "vendor": "Coinbase",
+                    "transaction_id": "CB-STAKE-2025-ABC",
+                    "transaction_type": "staking_reward",
+                    "extraction_method": "regex"
+                }
+            ]
+        },
+        {
+            "id": "binance_multi",
+            "from": "Binance <do-not-reply@binance.com>",
+            "subject": "Trade Confirmation",
+            "body": "Your trade order has been filled.\n\nOrder Details:\n- Pair: BTC/USDT\n- Side: Buy\n- Amount: 0.002 BTC\n- Price: 65,000.00 USDT\n- Total: 130.00 USDT\n\n- Pair: ETH/USDT\n- Side: Buy\n- Amount: 0.1 ETH\n- Price: 3,500.00 USDT\n- Total: 350.00 USDT",
+            "date": "Tue, 9 Jan 2024 18:00:00 +0000",
+            "expected": [
+                {
+                    "amount": 0.002,
+                    "item_name": "BTC",
+                    "total_spent": 130.0,
+                    "currency": "USDT",
+                    "vendor": "Binance",
+                    "extraction_method": "regex"
+                },
+                {
+                    "amount": 0.1,
+                    "item_name": "ETH",
+                    "total_spent": 350.0,
+                    "currency": "USDT",
+                    "vendor": "Binance",
+                    "extraction_method": "regex"
+                }
+            ]
+        },
+        {
+            "id": "generic_llm_purchase",
+            "from": "info@someexchange.io",
+            "subject": "Receipt for your order",
+            "body": "You bought 1000 DOGE for 0.1 ETH on our platform.",
+            "date": "Wed, 10 Jan 2024 19:00:00 +0000",
+            "expected": [
+                {
+                    "amount": 1000.0,
+                    "item_name": "DOGE",
+                    "total_spent": 0.1,
+                    "currency": "ETH",
+                    "vendor": "SomeExchange",
+                    "extraction_method": "llm"
+                }
+            ]
+        },
+        {
+            "id": "newsletter",
+            "from": "Newsletter <news@crypto.com>",
+            "subject": "Crypto Weekly",
+            "body": "Market is bullish today. Bitcoin is up 5%.",
+            "date": "Thu, 11 Jan 2024 20:00:00 +0000",
+            "expected": []
+        },
+        {
+            "id": "security_alert",
+            "from": "Security <security@binance.com>",
+            "subject": "New login from unknown device",
+            "body": "We detected a login from a new device in London.",
+            "date": "Fri, 12 Jan 2024 21:00:00 +0000",
+            "expected": []
+        }
+    ]
+
+    # Remove existing mbox if any
+    if os.path.exists(mbox_path):
+        os.remove(mbox_path)
+
+    mbox = mailbox.mbox(mbox_path)
+    expected_data = {}
+
+    for email_info in emails:
+        msg = mailbox.mboxMessage()
+        msg["From"] = email_info["from"]
+        msg["Subject"] = email_info["subject"]
+        msg["Date"] = email_info["date"]
+        msg["Message-ID"] = f"<{email_info['id']}@golden-test.local>"
+        msg.set_payload(email_info["body"])
+        mbox.add(msg)
+
+        expected_data[email_info["id"]] = email_info["expected"]
+
+    mbox.flush()
+    mbox.close()
+
+    with open(expected_path, "w") as f:
+        json.dump(expected_data, f, indent=4)
+        f.write("\n")
+
+    print(f"Generated {mbox_path} and {expected_path}")
+
+if __name__ == "__main__":
+    create_golden_mbox()

--- a/tests/integration/test_golden_mbox.py
+++ b/tests/integration/test_golden_mbox.py
@@ -1,0 +1,169 @@
+import json
+import pytest
+from unittest.mock import MagicMock
+from digital_asset_harvester import (
+    EmailPurchaseExtractor,
+    MboxDataExtractor,
+    get_settings_with_overrides,
+)
+from digital_asset_harvester.llm.provider import LLMResult
+
+@pytest.fixture
+def golden_expected():
+    with open("tests/fixtures/golden_expected.json", "r") as f:
+        return json.load(f)
+
+@pytest.fixture
+def mock_llm_client():
+    client = MagicMock()
+
+    def side_effect(prompt, retries=3):
+        prompt_lower = prompt.lower()
+        # Find the email content part of the prompt
+        email_content = ""
+        if "email content:" in prompt_lower:
+            # Split by common markers to isolate the email content
+            parts = prompt_lower.split("email content:")
+            if len(parts) > 1:
+                content_part = parts[1]
+                for marker in ["analysis criteria:", "extraction instructions:"]:
+                    if marker in content_part:
+                        content_part = content_part.split(marker)[0]
+                email_content = content_part
+
+        is_extraction = "return json with this exact structure" in prompt_lower and "transactions" in prompt_lower
+
+        email_id = None
+        if "generic_llm_purchase" in email_content or "someexchange" in email_content:
+            email_id = "generic_llm_purchase"
+        elif "newsletter" in email_content or "bullish" in email_content:
+            email_id = "newsletter"
+        elif "security" in email_content or "login" in email_content:
+            email_id = "security_alert"
+        elif "coinbase" in email_content:
+            if "staking reward" in email_content:
+                email_id = "coinbase_staking"
+            else:
+                email_id = "coinbase_purchase"
+        elif "binance" in email_content:
+            if "pair: btc/usdt" in email_content:
+                email_id = "binance_multi"
+            else:
+                email_id = "binance_purchase"
+        elif "kraken" in email_content:
+            email_id = "kraken_purchase"
+        elif "gemini" in email_content:
+            email_id = "gemini_purchase"
+        elif "crypto.com" in email_content or "2.5 sol" in email_content:
+            email_id = "cryptocom_purchase"
+        elif "ftx" in email_content or "matic" in email_content:
+            email_id = "ftx_purchase"
+        elif "coinspot" in email_content or "50 ada" in email_content:
+            email_id = "coinspot_purchase"
+
+        if not is_extraction:
+            # Classification
+            is_purchase = email_id not in ["newsletter", "security_alert", None]
+            return LLMResult(
+                data={
+                    "is_crypto_purchase": is_purchase,
+                    "confidence": 0.99,
+                    "reasoning": f"Identified as {email_id}"
+                },
+                raw_text="{}"
+            )
+        else:
+            # Extraction
+            if email_id == "generic_llm_purchase":
+                return LLMResult(
+                    data={
+                        "transactions": [
+                            {
+                                "transaction_type": "buy",
+                                "amount": 1000.0,
+                                "item_name": "DOGE",
+                                "total_spent": 0.1,
+                                "currency": "ETH",
+                                "vendor": "SomeExchange",
+                                "purchase_date": "2024-01-10 19:00:00",
+                                "confidence": 0.95,
+                                "extraction_notes": "Extracted from body"
+                            }
+                        ]
+                    },
+                    raw_text="{}"
+                )
+
+            # Others should be handled by regex and not even reach here if regex is enabled
+            return LLMResult(data={"transactions": []}, raw_text="{}")
+
+    client.generate_json.side_effect = side_effect
+    return client
+
+@pytest.mark.integration
+def test_golden_mbox_extraction(golden_expected, mock_llm_client):
+    """Verify extraction consistency against the golden mbox."""
+    mbox_path = "tests/fixtures/golden.mbox"
+    mbox_reader = MboxDataExtractor(mbox_path)
+
+    settings = get_settings_with_overrides(
+        enable_regex_extractors=True,
+        enable_preprocessing=True,
+        strict_validation=False,
+    )
+
+    extractor = EmailPurchaseExtractor(
+        settings=settings,
+        llm_client=mock_llm_client
+    )
+
+    emails = list(mbox_reader.extract_emails())
+    assert len(emails) == len(golden_expected)
+
+    for email in emails:
+        # Get ID from Message-ID header
+        msg_id = email.get("message_id", "")
+        email_id = msg_id.strip("<>").split("@")[0]
+
+        assert email_id in golden_expected, f"Email ID {email_id} not in expected results"
+        expected_purchases = golden_expected[email_id]
+
+        # Process the email
+        email_content = (
+            f"From: {email.get('sender', '')}\n"
+            f"Subject: {email.get('subject', '')}\n"
+            f"Date: {email.get('date', '')}\n\n"
+            f"{email.get('body', '')}"
+        )
+
+        result = extractor.process_email(email_content)
+
+        actual_purchases = result.get("purchases", [])
+
+        assert len(actual_purchases) == len(expected_purchases), \
+            f"Mismatch in number of purchases for {email_id}. Expected {len(expected_purchases)}, got {len(actual_purchases)}"
+
+        for i, expected in enumerate(expected_purchases):
+            actual = actual_purchases[i]
+
+            assert actual["item_name"].upper() == expected["item_name"].upper(), f"{email_id} asset mismatch"
+            assert float(actual["amount"]) == pytest.approx(float(expected["amount"])), f"{email_id} amount mismatch"
+
+            if "total_spent" in expected and expected["total_spent"] is not None:
+                assert float(actual["total_spent"]) == pytest.approx(float(expected["total_spent"])), f"{email_id} total_spent mismatch"
+
+            if "currency" in expected and expected["currency"] is not None:
+                assert actual["currency"] == expected["currency"], f"{email_id} currency mismatch"
+
+            assert actual["vendor"].lower() == expected["vendor"].lower(), f"{email_id} vendor mismatch"
+
+            if "transaction_id" in expected:
+                assert actual["transaction_id"] == expected["transaction_id"], f"{email_id} transaction_id mismatch"
+
+            if "transaction_type" in expected:
+                assert actual["transaction_type"] == expected["transaction_type"], f"{email_id} transaction_type mismatch"
+
+            assert actual["extraction_method"] == expected["extraction_method"], f"{email_id} extraction_method mismatch"
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
I have implemented a 'Golden mbox' integration test suite to ensure extraction consistency and prevent regressions.

Key accomplishments:
1.  **Representative Test Data**: Created `tests/fixtures/golden.mbox` containing 12 diverse email scenarios, including purchases from Coinbase, Binance, Kraken, Gemini, Crypto.com, FTX, and CoinSpot, as well as staking rewards and negative cases (newsletters/security alerts).
2.  **Ground Truth**: Created `tests/fixtures/golden_expected.json` which serves as the expected output for the extraction process, including asset IDs, amounts, currencies, and extraction methods.
3.  **Reproducible Generation**: Developed `tests/integration/generate_golden_mbox.py` to programmatically generate the test data and ground truth, making it easy to update or extend the suite in the future.
4.  **Integration Test Runner**: Implemented `tests/integration/test_golden_mbox.py` which uses `pytest` to iterate through the golden mbox, process each email using the `EmailPurchaseExtractor`, and assert that the results match the ground truth. It utilizes a `MockLLMClient` to provide deterministic results for LLM-based extraction while also verifying specialized regex extractors.
5.  **Robustness**: Used `pytest.approx` for floating-point comparisons and ensured all files follow project style guidelines (e.g., trailing newlines).
6.  **Verification**: Verified that the new tests pass and that no regressions were introduced to the existing 258 tests.

Fixes #111

---
*PR created automatically by Jules for task [11857131258914381522](https://jules.google.com/task/11857131258914381522) started by @username-anthony-is-not-available*