### PR TITLE
Implement EML File Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **EML File Support**: Batch processing of individual `.eml` files.
+  - New `EmlDataExtractor` for directory-based ingestion.
+  - CLI support via `--eml-dir` argument.
+  - Web UI support for multiple `.eml` file uploads.
+
 - **Ollama Auto-Fallback**: Automatic fallback to Cloud LLM if local Ollama is too slow.
   - New `FallbackLLMClient` to handle provider switching.
   - Configuration options: `enable_ollama_fallback`, `ollama_fallback_threshold_seconds`, `fallback_cloud_provider`.

--- a/digital_asset_harvester/__init__.py
+++ b/digital_asset_harvester/__init__.py
@@ -2,6 +2,7 @@
 
 from .config import HarvesterSettings, get_settings, get_settings_with_overrides, reload_settings
 from .ingest.mbox_data_extractor import MboxDataExtractor
+from .ingest.eml_reader import EmlDataExtractor
 from .llm import get_llm_client
 from .output.csv_writer import write_purchase_data_to_csv
 from .processing.email_purchase_extractor import EmailPurchaseExtractor
@@ -14,6 +15,7 @@ __all__ = [
     "HarvesterSettings",
     "get_llm_client",
     "MboxDataExtractor",
+    "EmlDataExtractor",
     "PurchaseRecord",
     "PurchaseValidator",
     "PromptManager",

--- a/digital_asset_harvester/cli.py
+++ b/digital_asset_harvester/cli.py
@@ -12,6 +12,7 @@ from digital_asset_harvester import (
     EmailPurchaseExtractor,
     HarvesterSettings,
     MboxDataExtractor,
+    EmlDataExtractor,
     get_llm_client,
     get_settings,
     log_event,
@@ -48,6 +49,7 @@ def build_parser(settings: HarvesterSettings) -> argparse.ArgumentParser:
     )
     source_group = parser.add_mutually_exclusive_group(required=True)
     source_group.add_argument("--mbox-file", help="Path to the mbox file")
+    source_group.add_argument("--eml-dir", help="Path to a directory containing .eml files")
     source_group.add_argument(
         "--gmail",
         action="store_true",
@@ -688,6 +690,20 @@ def run(argv: Optional[list[str]] = None) -> int:
                         settings,
                         args.koinly_upload,
                     )
+        elif args.eml_dir:
+            logger.info(f"Loading emails from directory {args.eml_dir}...")
+            eml_reader = EmlDataExtractor(args.eml_dir)
+            emails = eml_reader.extract_emails(raw=settings.enable_multiprocessing)
+            _process_and_save_results(
+                emails,
+                extractor,
+                logger_factory,
+                args.output,
+                args.output_format,
+                args.progress,
+                settings,
+                args.koinly_upload,
+            )
         else:
             logger.info(f"Loading emails from {args.mbox_file}...")
             mbox_reader = MboxDataExtractor(args.mbox_file)

--- a/digital_asset_harvester/ingest/eml_reader.py
+++ b/digital_asset_harvester/ingest/eml_reader.py
@@ -1,0 +1,39 @@
+import os
+import email
+from typing import Any, Dict, Generator
+from pathlib import Path
+
+from .email_parser import message_to_dict
+
+class EmlDataExtractor:
+    """Extracts data from a directory of .eml files."""
+
+    def __init__(self, eml_dir: str):
+        self.eml_dir = eml_dir
+
+    def extract_emails(self, raw: bool = False) -> Generator[Any, None, None]:
+        """
+        Walks the directory and extracts emails from .eml files.
+
+        Args:
+            raw: If True, yields raw message strings. Otherwise, yields dictionaries.
+        """
+        eml_path = Path(self.eml_dir)
+        if not eml_path.exists() or not eml_path.is_dir():
+            return
+
+        for root, _, files in os.walk(self.eml_dir):
+            for file in files:
+                if file.lower().endswith('.eml'):
+                    file_path = os.path.join(root, file)
+                    try:
+                        with open(file_path, 'rb') as f:
+                            msg = email.message_from_binary_file(f)
+
+                        if raw:
+                            yield msg.as_string()
+                        else:
+                            yield message_to_dict(msg)
+                    except Exception:
+                        # Skip files that can't be parsed
+                        continue

--- a/digital_asset_harvester/web/templates/index.html
+++ b/digital_asset_harvester/web/templates/index.html
@@ -35,9 +35,10 @@
         <p>Upload your mbox file or sync directly from your email inbox.</p>
 
         <div class="card">
-            <h2>Mbox Upload</h2>
+            <h2>Email File Upload</h2>
+            <p>Upload your .mbox file or multiple .eml files.</p>
             <form action="/api/upload" method="post" enctype="multipart/form-data" class="upload-form">
-                <input type="file" name="file">
+                <input type="file" name="files" multiple>
                 <input type="submit" value="Upload and Process">
             </form>
         </div>

--- a/tests/fixtures/emls/binance.eml
+++ b/tests/fixtures/emls/binance.eml
@@ -1,0 +1,8 @@
+From: binance@binance.com
+To: user@example.com
+Subject: Your order to buy 0.1 ETH has been filled
+Date: Tue, 13 Nov 2023 12:00:00 +0000
+Content-Type: text/plain; charset=utf-8
+
+Congratulations! Your order to buy 0.1 ETH for 200.00 USD has been filled.
+Order ID: BIN-123456

--- a/tests/fixtures/emls/coinbase.eml
+++ b/tests/fixtures/emls/coinbase.eml
@@ -1,0 +1,8 @@
+From: coinbase@coinbase.com
+To: user@example.com
+Subject: Your Coinbase purchase of 0.001 BTC
+Date: Mon, 12 Nov 2023 11:30:00 +0000
+Content-Type: text/plain; charset=utf-8
+
+You just bought 0.001 BTC for $100.00 USD.
+Transaction ID: CB-STAKE-2025-ABC

--- a/tests/ingest/test_eml_reader.py
+++ b/tests/ingest/test_eml_reader.py
@@ -1,0 +1,71 @@
+import os
+import pytest
+from pathlib import Path
+from digital_asset_harvester.ingest.eml_reader import EmlDataExtractor
+
+def test_eml_reader_initialization():
+    """Tests that the EmlDataExtractor can be initialized."""
+    reader = EmlDataExtractor("non_existent_dir")
+    assert reader is not None
+
+def test_eml_reader_extract_emails_dir_not_found():
+    """Tests that extract_emails returns an empty generator if the directory does not exist."""
+    reader = EmlDataExtractor("non_existent_dir")
+    emails = reader.extract_emails()
+    assert list(emails) == []
+
+def test_eml_reader_extract_emails_from_fixtures():
+    """Tests that extract_emails can extract emails from the fixtures directory."""
+    fixtures_dir = os.path.join("tests", "fixtures", "emls")
+    reader = EmlDataExtractor(fixtures_dir)
+    emails = list(reader.extract_emails())
+
+    assert len(emails) >= 2
+
+    subjects = [email["subject"] for email in emails]
+    assert "Your Coinbase purchase of 0.001 BTC" in subjects
+    assert "Your order to buy 0.1 ETH has been filled" in subjects
+
+    # Check bodies
+    coinbase_email = next(e for e in emails if "Coinbase" in e["subject"])
+    assert "0.001 BTC for $100.00 USD" in coinbase_email["body"]
+
+    binance_email = next(e for e in emails if "0.1 ETH" in e["subject"])
+    assert "0.1 ETH for 200.00 USD" in binance_email["body"]
+
+def test_eml_reader_raw_output():
+    """Tests that extract_emails can return raw message strings."""
+    fixtures_dir = os.path.join("tests", "fixtures", "emls")
+    reader = EmlDataExtractor(fixtures_dir)
+    emails = list(reader.extract_emails(raw=True))
+
+    assert len(emails) >= 2
+    assert isinstance(emails[0], str)
+    assert "Subject:" in emails[0]
+
+def test_eml_reader_nested_directories(tmp_path):
+    """Tests that the reader can walk through nested directories."""
+    nested_dir = tmp_path / "nested"
+    nested_dir.mkdir()
+
+    eml_content = """From: test@example.com
+Subject: Nested Email
+
+This is a nested email.
+"""
+    (nested_dir / "test.eml").write_text(eml_content)
+
+    reader = EmlDataExtractor(str(tmp_path))
+    emails = list(reader.extract_emails())
+
+    assert len(emails) == 1
+    assert emails[0]["subject"] == "Nested Email"
+
+def test_eml_reader_ignores_non_eml_files(tmp_path):
+    """Tests that the reader ignores files that do not have a .eml extension."""
+    (tmp_path / "test.txt").write_text("This is not an eml file.")
+
+    reader = EmlDataExtractor(str(tmp_path))
+    emails = list(reader.extract_emails())
+
+    assert len(emails) == 0

--- a/tests/web/test_web_ui.py
+++ b/tests/web/test_web_ui.py
@@ -37,7 +37,7 @@ def test_upload_file_and_get_results():
         f.write("dummy content")
 
     with open(test_mbox_path, "rb") as f:
-        response = client.post("/api/upload", files={"file": ("test.mbox", f, "application/octet-stream")})
+        response = client.post("/api/upload", files={"files": ("test.mbox", f, "application/octet-stream")})
 
     assert response.history[0].status_code == 303
     task_id = response.url.path.split("/")[-1]


### PR DESCRIPTION
This PR implements support for individual `.eml` files, allowing users to process them in batch without converting to `.mbox` first. It includes a new ingestion component, CLI integration, and Web UI enhancements for multiple file uploads.

Fixes #110

---
*PR created automatically by Jules for task [11992557756093334524](https://jules.google.com/task/11992557756093334524) started by @username-anthony-is-not-available*