### PR TITLE
Standardize Purchase Schema using Pydantic V2

### DIFF
--- a/digital_asset_harvester/exporters/cra.py
+++ b/digital_asset_harvester/exporters/cra.py
@@ -70,6 +70,8 @@ def write_purchase_data_to_cra_csv(purchases: List[Dict[str, Any]], output_file:
         for p in purchases:
             if isinstance(p, dict):
                 purchase_dicts.append(p)
+            elif hasattr(p, "model_dump"):
+                purchase_dicts.append(p.model_dump())
             else:
                 purchase_dicts.append(vars(p))
 
@@ -109,6 +111,8 @@ def write_purchase_data_to_cra_pdf(purchases: List[Dict[str, Any]], output_file:
     for p in purchases:
         if isinstance(p, dict):
             purchase_dicts.append(p)
+        elif hasattr(p, "model_dump"):
+            purchase_dicts.append(p.model_dump())
         else:
             purchase_dicts.append(vars(p))
 

--- a/digital_asset_harvester/exporters/cryptotaxcalculator.py
+++ b/digital_asset_harvester/exporters/cryptotaxcalculator.py
@@ -86,6 +86,8 @@ def write_purchase_data_to_ctc_csv(purchases: List[Dict[str, Any]], output_file:
         for p in purchases:
             if isinstance(p, dict):
                 purchase_dicts.append(p)
+            elif hasattr(p, "model_dump"):
+                purchase_dicts.append(p.model_dump())
             else:
                 purchase_dicts.append(vars(p))
 

--- a/digital_asset_harvester/exporters/koinly.py
+++ b/digital_asset_harvester/exporters/koinly.py
@@ -110,6 +110,8 @@ def write_purchase_data_to_koinly_csv(purchases: List[Dict[str, Any]], output_fi
         for p in purchases:
             if isinstance(p, dict):
                 purchase_dicts.append(p)
+            elif hasattr(p, "model_dump"):
+                purchase_dicts.append(p.model_dump())
             else:
                 purchase_dicts.append(vars(p))
 

--- a/tests/exporters/test_koinly.py
+++ b/tests/exporters/test_koinly.py
@@ -63,7 +63,7 @@ class TestKoinlyReportGenerator:
         generator = KoinlyReportGenerator()
 
         # Test "buy" transaction
-        buy_row = generator._convert_purchase_to_koinly_row(vars(sample_purchases[0]))
+        buy_row = generator._convert_purchase_to_koinly_row(sample_purchases[0].model_dump())
         assert buy_row["Label"] == "buy"
         assert buy_row["Sent Amount"] == "100.00"
         assert buy_row["Sent Currency"] == "USD"
@@ -73,7 +73,7 @@ class TestKoinlyReportGenerator:
         assert buy_row["Description"] == "Buy from Coinbase"
 
         # Test "deposit" transaction
-        deposit_row = generator._convert_purchase_to_koinly_row(vars(sample_purchases[1]))
+        deposit_row = generator._convert_purchase_to_koinly_row(sample_purchases[1].model_dump())
         assert deposit_row["Label"] == "deposit"
         assert deposit_row["Sent Amount"] == ""
         assert deposit_row["Sent Currency"] == ""
@@ -84,7 +84,7 @@ class TestKoinlyReportGenerator:
 
         # Test "withdrawal" transaction
         withdrawal_row = generator._convert_purchase_to_koinly_row(
-            vars(sample_purchases[2])
+            sample_purchases[2].model_dump()
         )
         assert withdrawal_row["Label"] == "withdrawal"
         assert withdrawal_row["Sent Amount"] == "2.0"
@@ -113,7 +113,7 @@ class TestKoinlyReportGenerator:
 
     def test_generate_csv_rows(self, sample_purchases):
         generator = KoinlyReportGenerator()
-        purchase_dicts = [vars(p) for p in sample_purchases]
+        purchase_dicts = [p.model_dump() for p in sample_purchases]
         rows = generator.generate_csv_rows(purchase_dicts)
         assert len(rows) == 3
         assert rows[0]["Label"] == "buy"

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,10 +1,14 @@
 from decimal import Decimal
+
 import pytest
+from pydantic import ValidationError
+
 from digital_asset_harvester.validation.schemas import PurchaseRecord
 
-def test_purchase_record_from_raw_handles_invalid_numeric():
-    with pytest.raises(ValueError):
-        PurchaseRecord.from_raw(
+
+def test_purchase_record_validate_handles_invalid_numeric():
+    with pytest.raises(ValidationError):
+        PurchaseRecord.model_validate(
             {
                 "total_spent": "invalid",
                 "currency": "USD",
@@ -14,3 +18,18 @@ def test_purchase_record_from_raw_handles_invalid_numeric():
                 "purchase_date": "2024-01-01 00:00:00 UTC",
             }
         )
+
+
+def test_purchase_record_handles_none_strings():
+    record = PurchaseRecord.model_validate(
+        {
+            "total_spent": "none",
+            "currency": "null",
+            "amount": "1.0",
+            "item_name": "BTC",
+            "vendor": "Coinbase",
+            "purchase_date": "2024-01-01",
+        }
+    )
+    assert record.total_spent is None
+    assert record.currency == ""

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,5 +1,7 @@
 from decimal import Decimal
+
 from digital_asset_harvester.validation import PurchaseRecord, PurchaseValidator
+
 
 def test_purchase_validator_handles_known_crypto():
     validator = PurchaseValidator(allow_unknown_crypto=False)
@@ -13,3 +15,19 @@ def test_purchase_validator_handles_known_crypto():
     )
     issues = validator.validate(record)
     assert not issues
+
+
+def test_purchase_validator_handles_unknown_crypto():
+    validator = PurchaseValidator(allow_unknown_crypto=False)
+    record = PurchaseRecord(
+        total_spent=Decimal("100.00"),
+        currency="USD",
+        amount=Decimal("1.0"),
+        item_name="MagicToken",
+        vendor="TestVendor",
+        purchase_date="2023-01-01",
+    )
+    issues = validator.validate(record)
+    assert len(issues) == 1
+    assert issues[0].field == "item_name"
+    assert issues[0].message == "unknown cryptocurrency"


### PR DESCRIPTION
Refactored the `PurchaseRecord` schema and associated validation logic to use Pydantic V2. This change standardizes data extraction across the codebase, improves validation robustness, and ensures consistent data for CSV/JSON exports. All tests passed, and legacy compatibility was maintained where possible (e.g., in exporters and the validation issue interface).

Fixes #109

---
*PR created automatically by Jules for task [16218423349783969914](https://jules.google.com/task/16218423349783969914) started by @username-anthony-is-not-available*